### PR TITLE
CRIMAP-219 Create via v2 api and store in postgres

### DIFF
--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -10,7 +10,7 @@ module Datastore
       error!({ status: 500, error: 'Missing range key' }, 500)
     end
 
-    rescue_from Dynamoid::Errors::RecordNotUnique do
+    rescue_from ActiveRecord::RecordNotUnique, Dynamoid::Errors::RecordNotUnique do
       error!({ status: 400, error: 'Record not unique' }, 400)
     end
 

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -5,5 +5,6 @@ module Datastore
 
     mount V1::Health
     mount V1::Applications
+    mount V2::Applications
   end
 end

--- a/app/api/datastore/v2/applications.rb
+++ b/app/api/datastore/v2/applications.rb
@@ -1,0 +1,19 @@
+module Datastore
+  module V2
+    class Applications < Base
+      version 'v2', using: :path
+
+      resource :applications do
+        desc 'Create an application.'
+        params do
+          requires :application, type: JSON, desc: 'Application JSON payload.'
+        end
+        post do
+          Operations::CreateApplication.new(
+            payload: params[:application]
+          ).call
+        end
+      end
+    end
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,0 +1,12 @@
+class CrimeApplication < ApplicationRecord
+  before_validation :set_id, on: :create
+
+  private
+
+  def set_id
+    return unless id.nil?
+    return unless application
+
+    self.id = application.fetch('id')
+  end
+end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -1,0 +1,28 @@
+require 'laa_crime_schemas'
+
+module Operations
+  class CreateApplication
+    attr_reader :payload
+
+    def initialize(payload:)
+      @payload = payload
+
+      validate!
+    end
+
+    def call
+      app = CrimeApplication.create!(application: payload)
+
+      { id: app.id, status: :created }
+    end
+
+    private
+
+    def validate!
+      schema_validator = LaaCrimeSchemas::Validator.new(payload)
+      return if schema_validator.valid?
+
+      raise LaaCrimeSchemas::Errors::ValidationError, schema_validator.fully_validate
+    end
+  end
+end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -13,7 +13,7 @@ module Operations
     def call
       app = CrimeApplication.create!(application: payload)
 
-      { id: app.id, status: :created }
+      { id: app.id }
     end
 
     private

--- a/db/migrate/20221130115736_create_crime_applications.rb
+++ b/db/migrate/20221130115736_create_crime_applications.rb
@@ -1,0 +1,9 @@
+class CreateCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :crime_applications, id: :uuid do |t|
+      t.jsonb :application
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_30_115736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "application"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/api/datastore/v2/applications_spec.rb
+++ b/spec/api/datastore/v2/applications_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::V2::Applications do
+  describe 'POST /api/applications' do
+    subject(:api_request) do
+      post '/api/v2/applications', params: { application: payload }
+    end
+
+    let(:record) { instance_double(CrimeApplication, id: '1234567') }
+    let(:payload) { LaaCrimeSchemas.fixture(1.0).read }
+
+    context 'with a valid request' do
+      before do
+        allow(CrimeApplication).to receive(:create!).with(
+          application: JSON.parse(payload)
+        ).and_return(record)
+
+        api_request
+      end
+
+      it 'stores the application in the datastore' do
+        expect(CrimeApplication).to have_received(:create!).with(
+          application: JSON.parse(payload)
+        )
+      end
+
+      it 'returns http status 201' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'includes the record id and status in the response body' do
+        expect(response.body).to match({
+          id: '1234567',
+          status: 'created'
+        }.to_json)
+      end
+    end
+
+    context 'when the application already exists' do
+      before do
+        allow(CrimeApplication).to receive(:create!).with(
+          application: JSON.parse(payload)
+        ) { raise ActiveRecord::RecordNotUnique }
+
+        api_request
+      end
+
+      it 'returns 400' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns error informatation' do
+        expect(response.body).to include('Record not unique')
+      end
+    end
+
+    context 'with a schema error' do
+      before do
+        allow(CrimeApplication).to receive(:create!).with(
+          application: JSON.parse(payload)
+        ).and_return(record)
+
+        api_request
+      end
+
+      let(:payload) do
+        LaaCrimeSchemas.fixture(1.0, name: :application_invalid).read
+      end
+
+      it 'does not store the application' do
+        expect(CrimeApplication).not_to have_received(:create!)
+      end
+
+      it 'returns 400' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns error informatation' do
+        expect(response.body).to include('failed_attribute')
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v2/applications_spec.rb
+++ b/spec/api/datastore/v2/applications_spec.rb
@@ -28,11 +28,8 @@ RSpec.describe Datastore::V2::Applications do
         expect(response).to have_http_status(:created)
       end
 
-      it 'includes the record id and status in the response body' do
-        expect(response.body).to match({
-          id: '1234567',
-          status: 'created'
-        }.to_json)
+      it 'includes the record id in the response body' do
+        expect(JSON.parse(response.body)).to match({ 'id' => '1234567' })
       end
     end
 

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe CrimeApplication do
+  let(:valid_attributes) do
+    { application: application_attributes }
+  end
+
+  let(:application_attributes) do
+    JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+  end
+
+  describe '#create' do
+    subject(:create) do
+      described_class.create(valid_attributes)
+    end
+
+    it 'persists the application' do
+      expect { create }.to change(described_class, :count).by 1
+    end
+
+    context 'when a record with the id already exists' do
+      before do
+        described_class.create!(id: application_attributes['id'])
+      end
+
+      it 'raises a RecordNotUnique error' do
+        expect { create }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+
+    describe 'the created application' do
+      subject(:application) { described_class.find(application_attributes['id']) }
+
+      before { create }
+
+      it 'has the same id as the document' do
+        expect(application).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds V2 endpoint for storing an application in the postgres datastore.

## Link to relevant ticket
CRIMAP-219-v2-api-create-application

## Notes for reviewer / how to test

Sets the database ID to that in the JSON payload. As with the V1 api, returns a 400 error if a record with that ID already exists.

Currently only the unit test are writing to the test DB. Happy to review this approach if others would prefer us to do it differently.

