### PR TITLE
CRIMAP-219 List applications filter and sort by status.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,3 +85,7 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - '**/spec/api/**/*'
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - '**/spec/api/datastore/v2/list_applications_spec.rb'

--- a/app/api/datastore/entities/crime_application.rb
+++ b/app/api/datastore/entities/crime_application.rb
@@ -2,6 +2,8 @@ module Datastore
   module Entities
     class CrimeApplication < Grape::Entity
       expose :application, merge: true
+
+      expose :status
     end
   end
 end

--- a/app/api/datastore/v2/applications.rb
+++ b/app/api/datastore/v2/applications.rb
@@ -27,9 +27,28 @@ module Datastore
         desc 'Return applications with pagination.'
         params do
           use :pagination
+
+          optional(
+            :status,
+            type: String,
+            default: nil,
+            desc: 'The status of the application.',
+            values: CrimeApplication::STATUSES
+          )
+
+          optional(
+            :sort,
+            type: Symbol,
+            default: :descending,
+            desc: 'Sort order for the records.',
+            values: %i[descending ascending]
+          )
         end
+
         get do
-          collection = CrimeApplication.page(params['page']).per(params['per_page'])
+          collection = Operations::ListApplications.new(
+            **params.symbolize_keys
+          ).call
 
           present :records, collection, with: Datastore::Entities::CrimeApplication
           present :pagination, collection, with: Datastore::Entities::Pagination

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,5 +1,13 @@
 class CrimeApplication < ApplicationRecord
+  attr_readonly :application, :submitted_at, :id
+
+  STATUSES = %w[submitted returned].freeze
+
   before_validation :set_id, on: :create
+
+  validates :status, presence: true, inclusion: { in: STATUSES }
+
+  scope :by_status, ->(status) { where(status:) }
 
   private
 

--- a/app/services/operations/list_applications.rb
+++ b/app/services/operations/list_applications.rb
@@ -1,0 +1,41 @@
+module Operations
+  class ListApplications
+    SORT_DIRECTIONS = {
+      descending: :desc,
+      ascending: :asc
+    }.freeze
+
+    def initialize(page:, per_page:, status:, sort:)
+      @page = page
+      @per_page = per_page
+      @status = status
+      @sort_direction = SORT_DIRECTIONS.fetch(sort)
+      @scope = CrimeApplication
+    end
+
+    def call
+      query
+        .order({ sort_by => sort_direction })
+        .page(page).per(per_page)
+    end
+
+    private
+
+    attr_reader :page, :per_page, :status, :sort_direction
+
+    def query
+      return @scope if status.nil?
+
+      @scope.by_status(status)
+    end
+
+    def sort_by
+      case status
+      when 'submitted', nil
+        :submitted_at
+      when 'returned'
+        :returned_at
+      end
+    end
+  end
+end

--- a/db/migrate/20221208165036_add_status_attributes_and_indexes_to_crime_applications.rb
+++ b/db/migrate/20221208165036_add_status_attributes_and_indexes_to_crime_applications.rb
@@ -1,0 +1,10 @@
+class AddStatusAttributesAndIndexesToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:crime_applications, "status", :text, null: false, default: 'submitted', index: true)
+    add_column(:crime_applications, :submitted_at, :timestamp, default: -> { 'CURRENT_TIMESTAMP' })
+    add_column(:crime_applications, :returned_at, :timestamp)
+
+    add_index(:crime_applications, [:status, :submitted_at], order: { submitted_at: :desc})
+    add_index(:crime_applications, [:status, :returned_at], order: { returned_at: :desc})
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_30_115736) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_165036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_30_115736) do
     t.jsonb "application"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "status", default: "submitted", null: false
+    t.datetime "submitted_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "returned_at", precision: nil
+    t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
+    t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
   end
 
 end

--- a/spec/api/datastore/v2/list_applications_spec.rb
+++ b/spec/api/datastore/v2/list_applications_spec.rb
@@ -2,27 +2,26 @@ require 'rails_helper'
 
 RSpec.describe 'list applications' do
   subject(:api_request) do
-    get "/api/v2/applications#{page_query}"
+    get "/api/v2/applications#{query}"
   end
+
+  let(:records_count) { JSON.parse(response.body).fetch('records').count }
 
   describe 'pagination' do
     subject(:pagination) do
       JSON.parse(response.body).fetch('pagination')
     end
 
-    let(:records_count) { JSON.parse(response.body).fetch('records').count }
-
     before do
-      # rubocop:disable Rails/SkipsModelValidations
       CrimeApplication.insert_all(
-        Array.new(21) { { application: { status: 'submitted' } } }
+        Array.new(10) { { status: 'submitted' } } +
+        Array.new(11) { { status: 'returned' } }
       )
-      # rubocop:enable Rails/SkipsModelValidations
       api_request
     end
 
     context 'without page param' do
-      let(:page_query) { nil }
+      let(:query) { nil }
 
       it 'returns the first page of results with pagination headers' do
         expect(pagination['current_page']).to eq 1
@@ -31,7 +30,7 @@ RSpec.describe 'list applications' do
     end
 
     context 'when page is specified' do
-      let(:page_query) { '?page=2' }
+      let(:query) { '?page=2' }
 
       it 'returns the correct page' do
         expect(pagination['current_page']).to eq 2
@@ -40,7 +39,7 @@ RSpec.describe 'list applications' do
     end
 
     context 'when page specified is out of range' do
-      let(:page_query) { '?page=5' }
+      let(:query) { '?page=5' }
 
       it 'returns an empty page' do
         expect(pagination['current_page']).to eq 5
@@ -49,7 +48,7 @@ RSpec.describe 'list applications' do
     end
 
     describe 'overiding the default per_page' do
-      let(:page_query) { '?per_page=3' }
+      let(:query) { '?per_page=3' }
 
       it 'returns results according to specified per_page' do
         expect(pagination['total_pages']).to eq 7
@@ -57,7 +56,7 @@ RSpec.describe 'list applications' do
       end
 
       context 'when outside of range' do
-        let(:page_query) { '?per_page=201' }
+        let(:query) { '?per_page=201' }
 
         it 'returns an error message' do
           expect(response).to have_http_status :bad_request
@@ -73,17 +72,79 @@ RSpec.describe 'list applications' do
     end
 
     before do
-      CrimeApplication.create(
-        application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
-      )
+      CrimeApplication.insert_all [
+        {
+          application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+          status: 'submitted', submitted_at: 1.day.ago, returned_at: nil
+        },
+        {
+          application: {},
+          status: 'returned', submitted_at: 1.week.ago, returned_at: Time.zone.now
+        }
+      ]
 
-      get '/api/v2/applications'
+      get "/api/v2/applications#{query}"
     end
+
+    let(:returned_statuses) { records.pluck('status').uniq }
+
+    let(:query) { nil }
 
     it 'is an array of valid crime application details' do
       expect(
         LaaCrimeSchemas::Validator.new(records.first, version: 1.0)
       ).to be_valid
+    end
+
+    describe 'status filter' do
+      it 'defaults to show all statuses' do
+        expect(records.size).to be(2)
+        expect(returned_statuses).to match %w[submitted returned]
+      end
+
+      CrimeApplication::STATUSES.each do |status|
+        context "when '#{status}'" do
+          let(:query) { "?status=#{status}" }
+
+          it "returns only #{status} applications" do
+            expect(records.size).to be(1)
+            expect(returned_statuses).to match [status]
+          end
+        end
+      end
+
+      context 'when status provided not supported"' do
+        let(:query) { '?status=deleted' }
+
+        it 'an error is returned' do
+          expect(response.body).to match 'status does not have a valid value'
+        end
+      end
+
+      describe 'sort' do
+        it 'defaults to descending' do
+          expect(records.size).to be(2)
+          expect(records.first['status']).to eq('submitted')
+        end
+
+        context 'when ascending is specified' do
+          let(:query) { '?sort=ascending' }
+
+          it 'the records are returned in ascending order' do
+            expect(records.size).to be(2)
+            expect(records.first['status']).to eq('returned')
+          end
+        end
+
+        context 'when descending is specified' do
+          let(:query) { '?sort=descending' }
+
+          it 'the records are returned in descending order' do
+            expect(records.size).to be(2)
+            expect(records.first['status']).to eq('submitted')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -11,7 +11,7 @@ describe CrimeApplication do
 
   describe '#create' do
     subject(:create) do
-      described_class.create(valid_attributes)
+      described_class.create!(valid_attributes)
     end
 
     it 'persists the application' do

--- a/spec/services/operations/list_applications_spec.rb
+++ b/spec/services/operations/list_applications_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'


### PR DESCRIPTION
## Description of change
Adds filtering by status and sorting to list applications.

Status can filter by "submitted" or "returned". If no status param is specified, all applications are shown.

Sort order can be specified. Default is descending. When status is submitted, or not specified, sort is based on submitted_at. When status is returned, sort is based on returned_at.

## Link to relevant ticket
[CRIMAP-219](https://dsdmoj.atlassian.net/browse/CRIMAP-219)

## Notes for reviewer / how to test

I'd like to propose that submitted_at and status should not be specified by apply on create. Instead status, submitted_at, returned_at etc should be the responsibility of the datastore. The data store will return these attributes in the document as per the schema.
