### PR TITLE
Crimre 83 filter by submitted at

### DIFF
--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -9,7 +9,10 @@ module Datastore
           optional :search, type: JSON, desc: 'Search JSON.' do
             optional :application_ids, type: Array
             optional :search_text, type: String
+            optional :submitted_after, type: DateTime
+            optional :submitted_before, type: DateTime
           end
+
           optional :pagination, type: JSON, desc: 'Pagination JSON.' do
             use :pagination
           end

--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -4,6 +4,8 @@ class SearchFilter
 
   attribute :application_ids, array: true, default: -> { [] }
   attribute :search_text, :string
+  attribute :submitted_after, :datetime
+  attribute :submitted_before, :datetime
 
   def active_filters
     attributes.compact_blank.keys
@@ -18,6 +20,14 @@ class SearchFilter
   end
 
   private
+
+  def filter_submitted_after(scope)
+    scope.where('submitted_at >  ?', submitted_after)
+  end
+
+  def filter_submitted_before(scope)
+    scope.where('submitted_at <  ?', submitted_before)
+  end
 
   def filter_application_ids(scope)
     scope.where(id: application_ids)

--- a/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'searches filter by id' do
   subject(:api_request) do
-    post '/api/v2/searches', params: { search:, pagination: }
+    post '/api/v2/searches', params: { search: search, pagination: {} }
   end
 
   let(:search) { {} }
-  let(:pagination) { {} }
   let(:records) { JSON.parse(response.body).fetch('records') }
 
   describe 'filter by application_id' do

--- a/spec/api/datastore/v2/searches/filter_by_submitted_at_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_submitted_at_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'searches filter by submitted_at' do
+  subject(:api_request) do
+    post '/api/v2/searches', params: { search: search, pagination: {} }
+  end
+
+  let(:search) { {} }
+  let(:records) { JSON.parse(response.body).fetch('records') }
+
+  before do
+    CrimeApplication.insert_all(
+      [
+        { submitted_at: 3.days.ago, application: { reference: 101 } },
+        { submitted_at: 2.days.ago, application: { reference: 102 } },
+        { submitted_at: 1.day.ago, application: { reference: 103 } }
+      ]
+    )
+
+    api_request
+  end
+
+  it 'defaults to showing all applications' do
+    expect(records.pluck('reference')).to eq([101, 102, 103])
+  end
+
+  context 'when submitted_after is provided' do
+    let(:search) { { submitted_after: 2.days.ago } }
+
+    it 'only shows records submitted after' do
+      expect(records.pluck('reference')).to eq([102, 103])
+    end
+  end
+
+  context 'when submitted_before is provided' do
+    let(:search) { { submitted_before: 2.days.ago } }
+
+    it 'only shows records submitted before' do
+      expect(records.pluck('reference')).to eq([101])
+    end
+  end
+end

--- a/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
@@ -8,62 +8,60 @@ RSpec.describe 'search with text' do
   let(:search) { { search_text: '' } }
   let(:records) { JSON.parse(response.body).fetch('records') }
 
-  describe 'filter by application_id' do
-    before do
-      details = %i[John Deere 1010 Ken John 1020 Jonathan Deere 1030].each_slice(3)
-      CrimeApplication.insert_all(
-        details.map do |first_name, last_name, reference|
-          {
-            application: {
-              client_details: {
-                applicant: { first_name:, last_name: }
-              },
-              reference: reference
-            }
+  before do
+    details = %i[John Deere 1010 Ken John 1020 Jonathan Deere 1030].each_slice(3)
+    CrimeApplication.insert_all(
+      details.map do |first_name, last_name, reference|
+        {
+          application: {
+            client_details: {
+              applicant: { first_name:, last_name: }
+            },
+            reference: reference
           }
-        end
-      )
-
-      api_request
-    end
-
-    it 'defaults to showing all applications' do
-      expect(records.count).to be 3
-      expect(records.pluck('resource_id')).to match(
-        CrimeApplication.pluck(:id)
-      )
-    end
-
-    context 'when first name is searched' do
-      let(:search) { { search_text: 'John' } }
-
-      it 'shows results that match the first name' do
-        expect(records.pluck('reference')).to match([1010, 1020])
+        }
       end
+    )
+
+    api_request
+  end
+
+  it 'defaults to showing all applications' do
+    expect(records.count).to be 3
+    expect(records.pluck('resource_id')).to match(
+      CrimeApplication.pluck(:id)
+    )
+  end
+
+  context 'when first name is searched' do
+    let(:search) { { search_text: 'John' } }
+
+    it 'shows results that match the first name' do
+      expect(records.pluck('reference')).to match([1010, 1020])
     end
+  end
 
-    context 'when reference is included' do
-      let(:search) { { search_text: 'Deere 1030' } }
+  context 'when reference is included' do
+    let(:search) { { search_text: 'Deere 1030' } }
 
-      it 'shows results that match the reference name' do
-        expect(records.pluck('reference')).to match([1030])
-      end
+    it 'shows results that match the reference name' do
+      expect(records.pluck('reference')).to match([1030])
     end
+  end
 
-    context 'when last_name is searched' do
-      let(:search) { { search_text: 'Deere' } }
+  context 'when last_name is searched' do
+    let(:search) { { search_text: 'Deere' } }
 
-      it 'shows results that match the last name' do
-        expect(records.pluck('reference')).to match([1010, 1030])
-      end
+    it 'shows results that match the last name' do
+      expect(records.pluck('reference')).to match([1010, 1030])
     end
+  end
 
-    context 'when first and last name are searched' do
-      let(:search) { { search_text: 'John Deere' } }
+  context 'when first and last name are searched' do
+    let(:search) { { search_text: 'John Deere' } }
 
-      it 'shows results that match the full name' do
-        expect(records.pluck('reference')).to match([1010])
-      end
+    it 'shows results that match the full name' do
+      expect(records.pluck('reference')).to match([1010])
     end
   end
 end


### PR DESCRIPTION
## Description of change

Searches can be filtered by submitted_at.
Uses two independent search params "submitted_before" and "submitted_after".

## Link to relevant ticket

## Notes for reviewer / how to test
