### PR TITLE
Implement scope by office code in list endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 02fc72cc0ddebbb0529cd95b997d778b409110f0
+  revision: 3dc6e047bcbf7ccb23e22ecd5aee7a7d30251730
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct
@@ -187,7 +187,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.0)
+    public_suffix (5.0.1)
     puma (6.0.0)
       nio4r (~> 2.0)
     racc (1.6.1)

--- a/app/api/datastore/v2/applications.rb
+++ b/app/api/datastore/v2/applications.rb
@@ -37,6 +37,13 @@ module Datastore
           )
 
           optional(
+            :office_code,
+            type: String,
+            default: nil,
+            desc: 'The office account number handling the application.'
+          )
+
+          optional(
             :sort,
             type: Symbol,
             default: :descending,

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -8,6 +8,9 @@ class CrimeApplication < ApplicationRecord
   validates :status, presence: true, inclusion: { in: STATUSES }
 
   scope :by_status, ->(status) { where(status:) }
+  scope :by_office, lambda { |office_code|
+    where("application->'provider_details'->>'office_code' = ?", office_code)
+  }
 
   private
 

--- a/app/services/operations/list_applications.rb
+++ b/app/services/operations/list_applications.rb
@@ -5,7 +5,8 @@ module Operations
       ascending: :asc
     }.freeze
 
-    def initialize(page:, per_page:, status:, sort:)
+    def initialize(office_code:, page:, per_page:, status:, sort:)
+      @office_code = office_code
       @page = page
       @per_page = per_page
       @status = status
@@ -21,12 +22,16 @@ module Operations
 
     private
 
-    attr_reader :page, :per_page, :status, :sort_direction
+    attr_reader :status, :office_code,
+                :page, :per_page, :sort_direction
 
     def query
-      return @scope if status.nil?
+      scope = @scope
 
-      @scope.by_status(status)
+      scope = scope.by_status(status) if status.present?
+      scope = scope.by_office(office_code) if office_code.present?
+
+      scope
     end
 
     def sort_by

--- a/spec/api/datastore/v2/list_applications_spec.rb
+++ b/spec/api/datastore/v2/list_applications_spec.rb
@@ -146,5 +146,26 @@ RSpec.describe 'list applications' do
         end
       end
     end
+
+    describe 'office_code filter' do
+      context 'when office_code matches any application' do
+        let(:query) { '?office_code=1A123B' }
+
+        it 'returns only matching applications' do
+          expect(records.size).to be(1)
+          expect(
+            records.first.dig('provider_details', 'office_code')
+          ).to eq('1A123B')
+        end
+      end
+
+      context 'when office_code does not match any application' do
+        let(:query) { '?office_code=XYZ123' }
+
+        it 'does not return applications' do
+          expect(records.size).to be(0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Apply requires filtering by office code. All requests to GET /applications will include, in addition to the `status` of the application, the `office_code` of the provider that submitted it.

I've done the filtering with a scope based on the JSON stored in the `application` DB field. This will unlock additional functionality on Apply side.

I'm sure there are better ways to do this, as this probably is slow, specially without an index. Please feel free to change this to virtual attributes or whatever if that's better.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-249

## Notes for reviewer / how to test
Apply is already submitting payloads containing the `office_code`.