### PR TITLE
CRIMRE-118 add filter by 'application id not in' to search.

### DIFF
--- a/app/api/datastore/entities/search_result.rb
+++ b/app/api/datastore/entities/search_result.rb
@@ -5,6 +5,7 @@ module Datastore
       expose :submitted_at
       expose :applicant_name
       expose :reference
+      expose :status
 
       private
 

--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -7,7 +7,8 @@ module Datastore
         desc 'Search the Datastore.'
         params do
           optional :search, type: JSON, desc: 'Search JSON.' do
-            optional :application_ids, type: Array
+            optional :application_id_in, type: Array
+            optional :application_id_not_in, type: Array
             optional :search_text, type: String
             optional :submitted_after, type: DateTime
             optional :submitted_before, type: DateTime
@@ -19,7 +20,8 @@ module Datastore
         end
 
         post do
-          search = Operations::Search.new(**declared(params).symbolize_keys).call
+          search_params = declared(params).symbolize_keys
+          search = Operations::Search.new(**search_params).call
           present :pagination, search, with: Datastore::Entities::Pagination
           present :records, search, with: Datastore::Entities::SearchResult
         end

--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -2,7 +2,8 @@ class SearchFilter
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :application_ids, array: true, default: -> { [] }
+  attribute :application_id_in, array: true, default: -> { [] }
+  attribute :application_id_not_in, array: true, default: -> { [] }
   attribute :search_text, :string
   attribute :submitted_after, :datetime
   attribute :submitted_before, :datetime
@@ -29,8 +30,12 @@ class SearchFilter
     scope.where('submitted_at <  ?', submitted_before)
   end
 
-  def filter_application_ids(scope)
-    scope.where(id: application_ids)
+  def filter_application_id_in(scope)
+    scope.where(id: application_id_in)
+  end
+
+  def filter_application_id_not_in(scope)
+    scope.where.not(id: application_id_not_in)
   end
 
   def filter_search_text(scope)

--- a/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
@@ -8,34 +8,52 @@ RSpec.describe 'searches filter by id' do
   let(:search) { {} }
   let(:records) { JSON.parse(response.body).fetch('records') }
 
-  describe 'filter by application_id' do
-    before do
-      CrimeApplication.insert_all(
-        Array.new(3) { { id: SecureRandom.uuid } }
-      )
+  before do
+    CrimeApplication.insert_all(
+      Array.new(3) { { id: SecureRandom.uuid } }
+    )
 
-      api_request
-    end
+    api_request
+  end
 
-    it 'defaults to showing all applications' do
-      expect(records.count).to be 3
-      expect(records.pluck('resource_id')).to match(
-        CrimeApplication.pluck(:id)
-      )
-    end
+  it 'defaults to showing all applications' do
+    expect(records.count).to be 3
+    expect(records.pluck('resource_id')).to match(
+      CrimeApplication.pluck(:id)
+    )
+  end
 
+  describe 'filter by application_id_in' do
     context 'when known applications_ids are provided' do
       let(:extant_ids) { CrimeApplication.limit(2).pluck(:id).to_a }
       let(:search) do
         {
-          # Inject an unknown id
-          application_ids: extant_ids.dup << SecureRandom.uuid
+          application_id_in: extant_ids.dup << SecureRandom.uuid
         }
       end
 
       it 'only shows results that match the application_id' do
         expect(records.count).to be 2
         expect(records.pluck('resource_id')).to match(extant_ids)
+      end
+    end
+  end
+
+  describe 'filter by application_id_not_in' do
+    context 'when known applications_ids are provided' do
+      let(:excluded_ids) { CrimeApplication.limit(2).pluck(:id).to_a }
+      let(:search) do
+        {
+          application_id_not_in: excluded_ids.dup << SecureRandom.uuid
+        }
+      end
+
+      it 'only shows applications that are not in the excluded_ids' do
+        expect(records.count).to be 1
+
+        expect(records.pluck('resource_id')).to match(
+          CrimeApplication.pluck(:id) - excluded_ids
+        )
       end
     end
   end

--- a/spec/models/search_filter_spec.rb
+++ b/spec/models/search_filter_spec.rb
@@ -12,10 +12,28 @@ describe SearchFilter do
       it { is_expected.to be_empty }
     end
 
-    context 'when aplication_ids are given' do
-      let(:params) { { application_ids: [SecureRandom.uuid] } }
+    context 'when aplication_id_in given' do
+      let(:params) { { application_id_in: [SecureRandom.uuid] } }
 
-      it { is_expected.to include 'application_ids' }
+      it { is_expected.to include 'application_id_in' }
+    end
+
+    context 'when aplication_id_in is empty array' do
+      let(:params) { { application_id_in: [] } }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when aplication_id_not_in given' do
+      let(:params) { { application_id_not_in: [SecureRandom.uuid] } }
+
+      it { is_expected.to include 'application_id_not_in' }
+    end
+
+    context 'when aplication_id_not_in is empty array' do
+      let(:params) { { application_id_not_in: [] } }
+
+      it { is_expected.to be_empty }
     end
 
     context 'when query text is provided' do


### PR DESCRIPTION
## Description of change
Adds `application_id_not_in` filter to search.
Changes `application_ids` filter to `application_id_in`.

## Link to relevant ticket
[CRIMRE-118](https://dsdmoj.atlassian.net/browse/CRIMRE-118)

## Notes for reviewer / how to test
Reviewers need to be able filter out assigned applications from the search.

