### PR TITLE
Bump schemas gem (legal rep details)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3dc6e047bcbf7ccb23e22ecd5aee7a7d30251730
+  revision: db240a50968304bc107320703502492d062c9bee
   specs:
     laa-criminal-legal-aid-schemas (0.1.0)
       dry-struct


### PR DESCRIPTION
## Description of change
Schema will start requiring the newly added legal representative details, on application submissions from Apply.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-224
