### PR TITLE
Update schema and add migration rake tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c33815dbdd4c3332f3c804e0437a630bf0881b2d
+  revision: ecb302f7456eb9839f63ff76774aaa33967ad4ab
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,5 +1,5 @@
 class CrimeApplication < ApplicationRecord
-  attr_readonly :application, :submitted_at, :id
+  attr_readonly :submitted_at, :id
 
   before_validation :set_id, on: :create
 

--- a/lib/tasks/misc.rake
+++ b/lib/tasks/misc.rake
@@ -1,0 +1,48 @@
+namespace :misc do
+  # NOTE: this task can be deleted once it has been run
+  desc 'Update offence dates to the new format'
+  task update_offences: :environment do
+    puts 'Migrating offence dates...'
+
+    CrimeApplication.find_each(batch_size: 30) do |record|
+      offences = record.application.dig('case_details', 'offences')
+
+      offences.each do |offence|
+        dates = offence.dig('dates')
+
+        dates.each.with_index do |date, index|
+          next if date.is_a?(Hash) # in case it has already the new format
+
+          puts "---> Updating app #{record.application['reference']} offence #{offence['name']} date #{date}..."
+
+          dates[index] = { date_from: date, date_to: nil }.as_json
+        end
+      end
+
+      record.save(touch: false)
+    end
+
+    puts 'All existing offence dates migrated to the new format.'
+  end
+
+  # NOTE: this task can be deleted once it has been run
+  desc 'Delete orphan applications'
+  task delete_orphans: :environment do
+    puts 'Deleting applications without provider details...'
+
+    uuids_to_remove = []
+
+    CrimeApplication.find_each(batch_size: 30) do |record|
+      details = record.application.dig('provider_details')
+
+      if details['office_code'].blank? || details['legal_rep_first_name'].blank?
+        puts "---> Application #{record.application['reference']} will be deleted ..."
+        uuids_to_remove << record.id
+      end
+    end
+
+    CrimeApplication.destroy_by(id: uuids_to_remove)
+
+    puts 'All applications without provider details have been deleted'
+  end
+end


### PR DESCRIPTION
## Description of change
The schemas gem has been updated to introduce the new offence dates format. Additionally the provider details struct has been made stricter (the schema was already enforcing this on submission).

Sadly current submitted applications are not compatible with the new data structures.

A couple of handy rake tasks are provided, to be run (just once really, can be removed at a later commit) and update the applications.

To be able to do this more easily making use of active record, temporarily the `application` attribute has been removed from the `attr_readonly` declaration.

More context here:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1673530745265879

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-251

## Notes for reviewer / how to test
The removal of the `attr_readonly` is only temporary to be able to run the rake tasks. Can be re-enabled soon after.
Once this is merged and deployed I will manually run the rake tasks and can raise another PR to remove the tasks and re-enable the readonly.