### PR TITLE
Bump schemas gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: ee9096e0bafa444f9ac999ed8e9580a62461fbe4
+  revision: 65f7b0b1f9807181fe48eb7a50ab657081c74bf0
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct


### PR DESCRIPTION
## Description of change
Ideally to synchronise with a deployment of Apply incorporating the new provider email attribute to the submitted applications.

It includes these changes to the schemas gem:

- Add provider email to the schema https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/commit/8f635e523435a307769970f33bc33efba821f9bd

- Remove required status attribute on submitted applications https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/commit/65f7b0b1f9807181fe48eb7a50ab657081c74bf0

## Link to relevant ticket
Partially related to:
https://dsdmoj.atlassian.net/browse/CRIMAP-121

## Notes for reviewer / how to test
