### PR TITLE
CRIMRE-52-add-application-return

### DIFF
--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -14,6 +14,10 @@ module Datastore
       error!({ status: 400, error: ex.message }, 400)
     end
 
+    rescue_from Errors::AlreadyReturned do
+      error!({ status: 409, error: 'Already Returned' }, 409)
+    end
+
     helpers do
       params :pagination do
         optional(

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -9,5 +9,6 @@ module Datastore
     mount V2::Health
     mount V2::Applications
     mount V2::Searches
+    mount V2::Reviewing
   end
 end

--- a/app/api/datastore/v2/reviewing.rb
+++ b/app/api/datastore/v2/reviewing.rb
@@ -1,0 +1,29 @@
+module Datastore
+  module V2
+    class Reviewing < Base
+      version 'v2', using: :path
+
+      resource :applications do
+        desc 'Return an applcation.'
+
+        params do
+          requires :application_id, type: String, desc: 'Crime Application UUID'
+          requires :return_details, type: JSON do
+            requires :reason_type, type: String, values: Types::RETURN_REASONS
+            requires :details, type: String, desc: 'Detailed reason for return'
+            requires :reason_text, type: String, desc: 'Return reason text'
+          end
+        end
+
+        route_param :application_id do
+          resource :return do
+            put do
+              return_params = declared(params).symbolize_keys
+              Operations::ReturnApplication.new(**return_params).call
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/datastore/v2/reviewing.rb
+++ b/app/api/datastore/v2/reviewing.rb
@@ -11,7 +11,6 @@ module Datastore
           requires :return_details, type: JSON do
             requires :reason_type, type: String, values: Types::RETURN_REASONS
             requires :details, type: String, desc: 'Detailed reason for return'
-            requires :reason_text, type: String, desc: 'Return reason text'
           end
         end
 

--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -1,5 +1,6 @@
 module Datastore
   module V2
+    # TODO: rename "Searching"
     class Searches < Base
       version 'v2', using: :path
 

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,0 +1,4 @@
+module Errors
+  class AlreadyReturned < StandardError
+  end
+end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -1,3 +1,16 @@
 module Types
   include LaaCrimeSchemas::Types
+
+  #
+  # TODO Get Return Types from LaaCrimeSchemas::Types once types have been added.
+  #
+  RETURN_REASONS = %w[
+    clarification_required
+    evidence_issue
+    duplicate_application
+    case_concluded
+    provider_request
+  ].freeze
+
+  ReturnReason = String.enum(*RETURN_REASONS)
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,4 +1,6 @@
 class CrimeApplication < ApplicationRecord
+  has_one :return_details, dependent: :destroy
+
   attr_readonly :application, :submitted_at, :id
 
   before_validation :set_id, on: :create
@@ -9,6 +11,10 @@ class CrimeApplication < ApplicationRecord
   scope :by_office, lambda { |office_code|
     where("application->'provider_details'->>'office_code' = ?", office_code)
   }
+
+  def returned?
+    !returned_at.nil?
+  end
 
   private
 

--- a/app/models/return_details.rb
+++ b/app/models/return_details.rb
@@ -1,0 +1,7 @@
+class ReturnDetails < ApplicationRecord
+  belongs_to :crime_application
+
+  validates :reason_type, inclusion: { in: Types::RETURN_REASONS }
+  validates :reason_text, presence: true
+  validates :details, presence: true
+end

--- a/app/models/return_details.rb
+++ b/app/models/return_details.rb
@@ -4,6 +4,5 @@ class ReturnDetails < ApplicationRecord
   belongs_to :crime_application
 
   validates :reason_type, inclusion: { in: Types::RETURN_REASONS }
-  validates :reason_text, presence: true
   validates :details, presence: true
 end

--- a/app/models/return_details.rb
+++ b/app/models/return_details.rb
@@ -1,4 +1,6 @@
 class ReturnDetails < ApplicationRecord
+  attr_readonly :reason_type, :crime_application_id, :details
+
   belongs_to :crime_application
 
   validates :reason_type, inclusion: { in: Types::RETURN_REASONS }

--- a/app/services/operations/return_application.rb
+++ b/app/services/operations/return_application.rb
@@ -1,0 +1,25 @@
+module Operations
+  class ReturnApplication
+    def initialize(application_id:, return_details:)
+      @application = CrimeApplication.find(application_id)
+      @return_details = @application.build_return_details(return_details)
+    end
+
+    def call
+      raise Errors::AlreadyReturned if application.returned?
+
+      application.transaction do
+        return_details.save!
+
+        application.update!(
+          status: Types::ApplicationStatus['returned'],
+          returned_at: Time.zone.now
+        )
+      end
+    end
+
+    private
+
+    attr_reader :application, :return_details
+  end
+end

--- a/db/migrate/20230120124639_create_return_details.rb
+++ b/db/migrate/20230120124639_create_return_details.rb
@@ -2,7 +2,6 @@ class CreateReturnDetails < ActiveRecord::Migration[7.0]
   def change
     create_table :return_details, id: :uuid do |t|
       t.string :reason_type, null: false
-      t.string :reason_text, null: false
       t.text :details
       t.references :crime_application, null: false, foreign_key: true, type: :uuid, unique: true
 

--- a/db/migrate/20230120124639_create_return_details.rb
+++ b/db/migrate/20230120124639_create_return_details.rb
@@ -1,0 +1,12 @@
+class CreateReturnDetails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :return_details, id: :uuid do |t|
+      t.string :reason_type, null: false
+      t.string :reason_text, null: false
+      t.text :details
+      t.references :crime_application, null: false, foreign_key: true, type: :uuid, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_12_140053) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_20_124639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,4 +33,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_140053) do
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
   end
 
+  create_table "return_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "reason_type", null: false
+    t.string "reason_text", null: false
+    t.text "details"
+    t.uuid "crime_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["crime_application_id"], name: "index_return_details_on_crime_application_id"
+  end
+
+  add_foreign_key "return_details", "crime_applications"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_20_124639) do
 
   create_table "return_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "reason_type", null: false
-    t.string "reason_text", null: false
     t.text "details"
     t.uuid "crime_application_id", null: false
     t.datetime "created_at", null: false

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'create application' do
   let(:return_details) do
     {
       reason_type: Types::RETURN_REASONS.sample,
-      reason_text: 'Text for reason type',
       details: 'Detailed reason why the application is being returned'
     }
   end

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'create application' do
+  let(:application) do
+    CrimeApplication.create!(
+      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  let(:return_details) do
+    {
+      reason_type: Types::RETURN_REASONS.sample,
+      reason_text: 'Text for reason type',
+      details: 'Detailed reason why the application is being returned'
+    }
+  end
+
+  describe 'PUT /api/applications/application_id/return' do
+    subject(:api_request) do
+      put(
+        "/api/v2/applications/#{application.id}/return",
+        params: { return_details: }
+      )
+    end
+
+    context 'with a submitted application' do
+      it 'marks the application as returned' do
+        expect { api_request }.to change { application.reload.status }
+          .from('submitted').to('returned')
+      end
+
+      it 'records the return details' do
+        expect { api_request }.to change(ReturnDetails, :count).from(0).to(1)
+      end
+
+      it 'records returned_at' do
+        expect { api_request }.to change { application.reload.returned_at }
+          .from(nil)
+      end
+    end
+
+    context 'with a returned application' do
+      before do
+        application.update!(returned_at: 1.week.ago)
+      end
+
+      it 'does not record the return details' do
+        expect { api_request }.not_to change(ReturnDetails, :count)
+        expect(response).to have_http_status :conflict
+      end
+    end
+
+    context 'with an unkown application' do
+      subject(:api_request) do
+        put(
+          "/api/v2/applications/#{SecureRandom.uuid}/return",
+          params: { return_details: }
+        )
+      end
+
+      it 'does not record the return details' do
+        expect { api_request }.not_to change(ReturnDetails, :count)
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v2/searches/filter_by_status_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_status_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'searches filter by status' do
 
     it 'returns records with a status in statuses' do
       expect(records.count).to be 3
-      expect(records.pluck('status').uniq).to eq(%w[submitted returned])
+      expect(records.pluck('status').uniq).to match(%w[submitted returned])
     end
   end
 end

--- a/spec/services/operations/list_applications_spec.rb
+++ b/spec/services/operations/list_applications_spec.rb
@@ -1,1 +1,0 @@
-require 'rails_helper'

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -12,7 +12,6 @@ describe Operations::ReturnApplication do
   let(:return_details) do
     {
       reason_type: Types::RETURN_REASONS.sample,
-      reason_text: 'Text for reason type',
       details: 'Detailed reason why the application is being returned'
     }
   end
@@ -64,12 +63,6 @@ describe Operations::ReturnApplication do
           it { is_expected.not_to be_nil }
         end
 
-        describe '#reason_text' do
-          subject(:reason_type) { detail.reason_text }
-
-          it { is_expected.to eq 'Text for reason type' }
-        end
-
         describe '#detail' do
           subject(:reason_type) { detail.details }
 
@@ -88,7 +81,6 @@ describe Operations::ReturnApplication do
       let(:return_details) do
         {
           reason_type: 'not_a_valid_type',
-          reason_text: 'Text for reason type',
           details: 'Detailed reason why the application is being returned'
         }
       end

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+describe Operations::ReturnApplication do
+  before do
+    CrimeApplication.create(
+      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    )
+  end
+
+  let(:application_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+
+  let(:return_details) do
+    {
+      reason_type: Types::RETURN_REASONS.sample,
+      reason_text: 'Text for reason type',
+      details: 'Detailed reason why the application is being returned'
+    }
+  end
+
+  let(:service) { described_class.new(application_id:, return_details:) }
+
+  describe '#call' do
+    subject(:call) { service.call }
+
+    let(:application) do
+      CrimeApplication.find(application_id)
+    end
+
+    context 'with valid attributes' do
+      it "updates the application's status to 'returned'" do
+        expect { call }.to change { application.reload.status }
+          .from('submitted').to('returned')
+      end
+
+      it "sets application's 'returned_at'" do
+        expect { call }.to change { application.reload.returned_at.class }
+          .from(NilClass).to(ActiveSupport::TimeWithZone)
+      end
+
+      context 'when application has already been returned' do
+        before { application.update(returned_at: 1.day.ago) }
+
+        it 'raises AlreadyReturned error' do
+          expect { call }.to raise_error Errors::AlreadyReturned
+        end
+      end
+
+      context 'when application is not found' do
+        let(:application_id) { SecureRandom.uuid }
+
+        it 'raises AlreadyReturned error' do
+          expect { call }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+
+      describe 'ReturnDetails' do
+        subject(:detail) { application.reload.return_details }
+
+        before { call }
+
+        describe '#reason_type' do
+          subject(:reason_type) { detail.reason_type }
+
+          it { is_expected.not_to be_nil }
+        end
+
+        describe '#reason_text' do
+          subject(:reason_type) { detail.reason_text }
+
+          it { is_expected.to eq 'Text for reason type' }
+        end
+
+        describe '#detail' do
+          subject(:reason_type) { detail.details }
+
+          it { is_expected.to eq 'Detailed reason why the application is being returned' }
+        end
+
+        describe '#crime_application' do
+          subject(:reason_type) { detail.crime_application }
+
+          it { is_expected.to be application }
+        end
+      end
+    end
+
+    context 'with invalid reason type' do
+      let(:return_details) do
+        {
+          reason_type: 'not_a_valid_type',
+          reason_text: 'Text for reason type',
+          details: 'Detailed reason why the application is being returned'
+        }
+      end
+
+      it 'raises ActiveRecord::RecordInvalid error and does not update the application' do
+        expect do
+          call
+        end.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Reason type is not included in the list'
+        expect(application.reload.status).to eq('submitted')
+      end
+    end
+  end
+end

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -48,7 +48,7 @@ describe Operations::ReturnApplication do
       context 'when application is not found' do
         let(:application_id) { SecureRandom.uuid }
 
-        it 'raises AlreadyReturned error' do
+        it 'raises RecordNotFound error' do
           expect { call }.to raise_error ActiveRecord::RecordNotFound
         end
       end
@@ -94,9 +94,11 @@ describe Operations::ReturnApplication do
       end
 
       it 'raises ActiveRecord::RecordInvalid error and does not update the application' do
-        expect do
-          call
-        end.to raise_error ActiveRecord::RecordInvalid, 'Validation failed: Reason type is not included in the list'
+        expect { call }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          'Validation failed: Reason type is not included in the list'
+        )
+
         expect(application.reload.status).to eq('submitted')
       end
     end


### PR DESCRIPTION
## Description of change

Adds application return endpoint. Put request to: applications/:id/return

idempotent

Returns 409 if already returned, 404 if the application cannot be found.

## Link to relevant ticket

[CRIMRE-52](https://dsdmoj.atlassian.net/browse/CRIMRE-52)

## Notes for reviewer / how to test

An additional PR to exposed the return_details to the application json will follow.
I have namespaced the code 'reviewing' with a view to all review actions living here. (Although the endpoints themselves remain resource based.)

This pattern could be followed by adding the following namespaces:
- Reviewing
- Applying
- Searching
- Reporting

[CRIMRE-52]: https://dsdmoj.atlassian.net/browse/CRIMRE-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

