### PR TITLE
Crimre 52 show return details for returned applications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 65f7b0b1f9807181fe48eb7a50ab657081c74bf0
+  revision: c7febd8d13df6522d19971d0a37db0095abb45b2
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct

--- a/app/api/datastore/entities/crime_application.rb
+++ b/app/api/datastore/entities/crime_application.rb
@@ -4,6 +4,7 @@ module Datastore
       expose :application, merge: true
 
       expose :status
+      expose :return_details, using: ReturnDetails, expose_nil: false
     end
   end
 end

--- a/app/api/datastore/entities/return_details.rb
+++ b/app/api/datastore/entities/return_details.rb
@@ -1,0 +1,9 @@
+module Datastore
+  module Entities
+    class ReturnDetails < Grape::Entity
+      expose :reason
+      expose :details
+      expose :created_at, as: :returned_at
+    end
+  end
+end

--- a/app/api/datastore/entities/search_result.rb
+++ b/app/api/datastore/entities/search_result.rb
@@ -3,6 +3,7 @@ module Datastore
     class SearchResult < Grape::Entity
       expose :id, as: :resource_id
       expose :submitted_at
+      expose :reviewed_at
       expose :applicant_name
       expose :reference
       expose :status

--- a/app/api/datastore/v2/reviewing.rb
+++ b/app/api/datastore/v2/reviewing.rb
@@ -18,7 +18,8 @@ module Datastore
           resource :return do
             put do
               return_params = declared(params).symbolize_keys
-              Operations::ReturnApplication.new(**return_params).call
+              app = Operations::ReturnApplication.new(**return_params).call
+              present app, with: Datastore::Entities::CrimeApplication
             end
           end
         end

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -1,16 +1,3 @@
 module Types
   include LaaCrimeSchemas::Types
-
-  #
-  # TODO Get Return Types from LaaCrimeSchemas::Types once types have been added.
-  #
-  RETURN_REASONS = %w[
-    clarification_required
-    evidence_issue
-    duplicate_application
-    case_concluded
-    provider_request
-  ].freeze
-
-  ReturnReason = String.enum(*RETURN_REASONS)
 end

--- a/app/services/operations/return_application.rb
+++ b/app/services/operations/return_application.rb
@@ -16,6 +16,8 @@ module Operations
           returned_at: return_details.created_at
         )
       end
+
+      application
     end
 
     private

--- a/app/services/operations/return_application.rb
+++ b/app/services/operations/return_application.rb
@@ -13,7 +13,9 @@ module Operations
 
         application.update!(
           status: Types::ApplicationStatus['returned'],
-          returned_at: return_details.created_at
+          review_status: Types::ReviewApplicationStatus['returned_to_provider'],
+          returned_at: return_details.created_at,
+          reviewed_at: Time.zone.now
         )
       end
 

--- a/db/migrate/20230125091219_tidy_review_attributes.rb
+++ b/db/migrate/20230125091219_tidy_review_attributes.rb
@@ -1,0 +1,13 @@
+class TidyReviewAttributes < ActiveRecord::Migration[7.0]
+  def change
+    change_table :crime_applications do |t|
+      t.remove_index ["status", "review_completed_at"]
+      t.remove_index ["review_status", "review_completed_at"]
+      t.rename :review_completed_at, :reviewed_at
+      t.remove :review_received_at
+      t.remove :return_reason
+    end
+
+    add_index(:crime_applications, [:status, :reviewed_at], order: { reviewed_at: :desc} )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_120841) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_091219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,14 +22,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_120841) do
     t.datetime "submitted_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "returned_at", precision: nil
     t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (application ->> 'reference'::text)))", stored: true
-    t.datetime "review_completed_at", precision: nil
+    t.datetime "reviewed_at", precision: nil
     t.string "review_status"
-    t.datetime "review_received_at", precision: nil
-    t.jsonb "return_reason", default: {}
-    t.index ["review_status", "review_completed_at"], name: "index_crime_apps_on_review_status_and_review_completed_at", order: { review_completed_at: :desc }
     t.index ["searchable_text"], name: "index_crime_applications_on_searchable_text", using: :gin
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
-    t.index ["status", "review_completed_at"], name: "index_crime_applications_on_status_and_review_completed_at", order: { review_completed_at: :desc }
+    t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
   end
 

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -36,6 +36,35 @@ RSpec.describe 'create application' do
         expect { api_request }.to change { application.reload.returned_at }
           .from(nil)
       end
+
+      describe 'returned application' do
+        subject(:returned_application) { JSON.parse(response.body) }
+
+        before { api_request }
+
+        describe 'status' do
+          subject(:status) { returned_application['status'] }
+
+          it { is_expected.to eq Types::ApplicationStatus['returned'] }
+        end
+
+        describe 'return_details' do
+          subject(:details) { returned_application['return_details'] }
+
+          it 'include the reason' do
+            expect(details['reason']).to eq return_details.fetch(:reason)
+          end
+
+          it 'include the details' do
+            expect(details['details']).to eq return_details.fetch(:details)
+          end
+
+          it 'include the returned_at' do
+            expect(details['returned_at'].to_time)
+              .to be_within(0.001).of(ReturnDetails.last.created_at)
+          end
+        end
+      end
     end
 
     context 'with a returned application' do

--- a/spec/api/datastore/v2/searches/filter_by_review_status_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_review_status_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe 'searches filter by review status' do
 
   it 'defaults to returning all statuses' do
     expect(records.count).to be 4
-    expect(records.pluck('review_status').uniq).to eq(%w[application_received returned_to_provider
-                                                         ready_for_assessment])
+    expect(records.pluck('review_status').uniq).to eq(
+      %w[application_received returned_to_provider ready_for_assessment]
+    )
   end
 
   describe 'filtering by "returned_to_provider"' do

--- a/spec/api/datastore/v2/searches/filter_by_submitted_at_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_submitted_at_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe 'searches filter by submitted_at' do
   end
 
   it 'defaults to showing all applications' do
-    expect(records.pluck('reference')).to match([101, 102, 103])
+    expect(records.pluck('reference')).to match_array([101, 102, 103])
   end
 
   context 'when submitted_after is provided' do
     let(:search) { { submitted_after: 2.days.ago } }
 
     it 'only shows records submitted after' do
-      expect(records.pluck('reference')).to match([102, 103])
+      expect(records.pluck('reference')).to match_array([102, 103])
     end
   end
 

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -31,8 +31,17 @@ describe Operations::ReturnApplication do
           .from('submitted').to('returned')
       end
 
+      it "updates the application's review status to 'returned_to_provider'" do
+        expect { call }.to change { application.reload.review_status }.to('returned_to_provider')
+      end
+
       it "sets application's 'returned_at'" do
         expect { call }.to change { application.reload.returned_at.class }
+          .from(NilClass).to(ActiveSupport::TimeWithZone)
+      end
+
+      it "sets application's 'reviewed_at'" do
+        expect { call }.to change { application.reload.reviewed_at.class }
           .from(NilClass).to(ActiveSupport::TimeWithZone)
       end
 


### PR DESCRIPTION
## Description of change

applications/:id/return responds with the updated application's json
Return details are included in the application json for returned crime applications .

## Link to relevant ticket
[CRIMRE-52](https://dsdmoj.atlassian.net/browse/CRIMRE-52)

## Notes for reviewer / how to test

[CRIMRE-52]: https://dsdmoj.atlassian.net/browse/CRIMRE-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ