### PR TITLE
Crimre 142 add sort search

### DIFF
--- a/app/api/datastore/entities/sorting.rb
+++ b/app/api/datastore/entities/sorting.rb
@@ -1,0 +1,8 @@
+module Datastore
+  module Entities
+    class Sorting < Grape::Entity
+      expose :sort_by
+      expose :sort_direction
+    end
+  end
+end

--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -29,7 +29,7 @@ module Datastore
             optional :submitted_before, type: DateTime
           end
 
-          optional :sorting, type: JSON, desc: 'Sorting JSON.' do
+          optional :sorting, type: JSON, desc: 'Sorting JSON.', default: Sorting.new.attributes do
             use :sorting
           end
 

--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -29,6 +29,10 @@ module Datastore
             optional :submitted_before, type: DateTime
           end
 
+          optional :sorting, type: JSON, desc: 'Sorting JSON.' do
+            use :sorting
+          end
+
           optional :pagination, type: JSON, desc: 'Pagination JSON.' do
             use :pagination
           end
@@ -36,9 +40,12 @@ module Datastore
 
         post do
           search_params = declared(params).symbolize_keys
-          search = Operations::Search.new(**search_params).call
-          present :pagination, search, with: Datastore::Entities::Pagination
-          present :records, search, with: Datastore::Entities::SearchResult
+          search = Operations::Search.new(**search_params)
+          records = search.call
+
+          present :pagination, records, with: Datastore::Entities::Pagination
+          present :sorting, search.sorting, with: Datastore::Entities::Sorting
+          present :records, records, with: Datastore::Entities::SearchResult
         end
       end
     end

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -29,10 +29,10 @@ class Sorting
   private
 
   def column
-    SORT_COLUMNS.fetch(sort_by.to_sym)
+    SORT_COLUMNS.fetch(sort_by&.to_sym || DEFAULT_SORT_BY)
   end
 
   def direction
-    SORT_DIRECTIONS.fetch(sort_direction.to_sym)
+    SORT_DIRECTIONS.fetch(sort_direction&.to_sym || DEFAULT_DIRECTION)
   end
 end

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -13,6 +13,7 @@ class Sorting
     reference: :reference,
     submitted_at: :submitted_at,
     returned_at: :returned_at,
+    reviewed_at: :reviewed_at,
   }.freeze
 
   DEFAULT_SORT_BY = :submitted_at

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -29,10 +29,10 @@ class Sorting
   private
 
   def column
-    SORT_COLUMNS.fetch(sort_by&.to_sym || DEFAULT_SORT_BY)
+    SORT_COLUMNS.fetch(sort_by.to_sym)
   end
 
   def direction
-    SORT_DIRECTIONS.fetch(sort_direction&.to_sym || DEFAULT_DIRECTION)
+    SORT_DIRECTIONS.fetch(sort_direction.to_sym)
   end
 end

--- a/app/services/operations/search.rb
+++ b/app/services/operations/search.rb
@@ -1,22 +1,28 @@
 module Operations
   class Search
-    def initialize(search:, pagination:, scope: CrimeApplication)
+    attr_reader :search_filter, :pagination, :sorting
+
+    def initialize(search:, pagination:, sorting:, scope: CrimeApplication)
       @search_filter = SearchFilter.new(search)
       @pagination = Pagination.new(pagination)
+      @sorting = Sorting.new(sorting)
       @scope = scope
     end
 
     def call
       filter
+      sort
       paginate
     end
 
     private
 
-    attr_reader :search_filter, :pagination
-
     def filter
       @scope = search_filter.apply_to_scope(@scope)
+    end
+
+    def sort
+      @scope = sorting.apply_to_scope(@scope)
     end
 
     def paginate

--- a/spec/api/datastore/v2/searches/sorting_spec.rb
+++ b/spec/api/datastore/v2/searches/sorting_spec.rb
@@ -18,9 +18,36 @@ RSpec.describe 'Sorting applications' do
     {}
   end
 
-  let(:records_count) { JSON.parse(response.body).fetch('records').count }
+  let(:records) { JSON.parse(response.body).fetch('records') }
+  let(:records_count) { records.count }
+
+  let(:applications) do
+    [
+      {
+        application: {},
+        status: 'submitted', submitted_at: 1.day.ago, returned_at: nil,
+        reviewed_at: nil
+      },
+      {
+        application: {},
+        status: 'submitted', submitted_at: 2.days.ago, returned_at: nil,
+        reviewed_at: nil
+      },
+      {
+        application: {},
+        status: 'returned', submitted_at: 1.week.ago, returned_at: 8.days.ago,
+        reviewed_at: 8.days.ago
+      },
+      {
+        application: {},
+        status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago,
+        reviewed_at: 5.days.ago
+      },
+    ]
+  end
 
   before do
+    CrimeApplication.insert_all(applications)
     api_request
   end
 
@@ -56,80 +83,75 @@ RSpec.describe 'Sorting applications' do
       end
     end
 
-    # context 'when status is `submitted`' do
-    #   context 'when sorting by `submitted_at`' do
-    #     context 'when direction is `ascending`' do
-    #       let(:query) { '?status=submitted&sort_by=submitted_at&sort_direction=asc' }
+    context 'when a search is performed' do
+      let(:search) do
+        {
+          status: %w[submitted returned]
+        }
+      end
 
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
+      context 'when sorting by `submitted_at`' do
+        context 'when direction is `ascending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'ascending',
+              'sort_by' => 'submitted_at'
+            }
+          end
 
-    #         expect(records.pluck('status')).to all(eq('submitted'))
-    #         expect(records.first['submitted_at']).to be < records.second['submitted_at']
-    #       end
-    #     end
+          it 'the records are returned in ascending order' do
+            expect(records_count).to be(4)
 
-    #     context 'when direction is `descending`' do
-    #       let(:query) { '?status=submitted&sort_by=submitted_at&sort_direction=desc' }
+            expect(records.first['submitted_at']).to be < records.second['submitted_at']
+          end
+        end
 
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
+        context 'when direction is `descending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'descending',
+              'sort_by' => 'submitted_at'
+            }
+          end
 
-    #         expect(records.pluck('status')).to all(eq('submitted'))
-    #         expect(records.first['submitted_at']).to be > records.second['submitted_at']
-    #       end
-    #     end
-    #   end
-    # end
+          it 'the records are returned in ascending order' do
+            expect(records.size).to be(4)
 
-    # context 'when status is `returned`' do
-    #   context 'when sorting by `submitted_at`' do
-    #     context 'when direction is `ascending`' do
-    #       let(:query) { '?status=returned&sort_by=submitted_at&sort_direction=asc' }
+            expect(records.first['submitted_at']).to be > records.second['submitted_at']
+          end
+        end
+      end
 
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
+      context 'when sorting by `reviewed_at`' do
+        context 'when direction is `ascending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'ascending',
+              'sort_by' => 'reviewed_at'
+            }
+          end
 
-    #         expect(records.pluck('status')).to all(eq('returned'))
-    #         expect(records.first['submitted_at']).to be < records.second['submitted_at']
-    #       end
-    #     end
+          it 'the records are returned in ascending order' do
+            expect(records_count).to be(4)
 
-    #     context 'when direction is `descending`' do
-    #       let(:query) { '?status=returned&sort_by=submitted_at&sort_direction=desc' }
+            expect(records.first['reviewed_at']).to be < records.second['reviewed_at']
+          end
+        end
 
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
+        context 'when direction is `descending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'descending',
+              'sort_by' => 'reviewed_at'
+            }
+          end
 
-    #         expect(records.pluck('status')).to all(eq('returned'))
-    #         expect(records.first['submitted_at']).to be > records.second['submitted_at']
-    #       end
-    #     end
-    #   end
-
-    #   context 'when sorting by `returned_at`' do
-    #     context 'when direction is ascending' do
-    #       let(:query) { '?status=returned&sort_by=returned_at&sort_direction=asc' }
-
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
-
-    #         expect(records.pluck('status')).to all(eq('returned'))
-    #         expect(records.first['returned_at']).to be < records.second['returned_at']
-    #       end
-    #     end
-
-    #     context 'when direction is descending' do
-    #       let(:query) { '?status=returned&sort_by=returned_at&sort_direction=desc' }
-
-    #       it 'the records are returned in ascending order' do
-    #         expect(records.size).to be(2)
-
-    #         expect(records.pluck('status')).to all(eq('returned'))
-    #         expect(records.first['returned_at']).to be > records.second['returned_at']
-    #       end
-    #     end
-    #   end
-    # end
+          it 'the records are returned in ascending order' do
+            expect(records.first['reviewed_at']).to be_nil
+            expect(records.third['reviewed_at']).to be > records.fourth['reviewed_at']
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/api/datastore/v2/searches/sorting_spec.rb
+++ b/spec/api/datastore/v2/searches/sorting_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe 'Sorting applications' do
+  subject(:api_request) do
+    post '/api/v2/searches', params: {
+      search: search, sorting: sorting_params
+    }
+  end
+
+  let(:sorting_params) do
+    {
+      sort_direction: 'descending',
+      sort_by: 'submitted_at'
+    }
+  end
+
+  let(:search) do
+    {}
+  end
+
+  let(:records_count) { JSON.parse(response.body).fetch('records').count }
+
+  before do
+    api_request
+  end
+
+  describe 'sorting' do
+    subject(:sorting) do
+      JSON.parse(response.body).fetch('sorting')
+    end
+
+    describe 'default sorting' do
+      it 'defaults to submitted_at and descending' do
+        expected_result = {
+          'sort_direction' => 'descending',
+          'sort_by' => 'submitted_at'
+        }
+        expect(sorting).to eq(expected_result)
+      end
+    end
+
+    describe 'Setting sort params' do
+      let(:sorting_params) do
+        {
+          'sort_direction' => 'ascending',
+          'sort_by' => 'reviewed_at'
+        }
+      end
+
+      it 'applies the params' do
+        expected_result = {
+          'sort_direction' => 'ascending',
+          'sort_by' => 'reviewed_at'
+        }
+        expect(sorting).to eq(expected_result)
+      end
+    end
+
+    # context 'when status is `submitted`' do
+    #   context 'when sorting by `submitted_at`' do
+    #     context 'when direction is `ascending`' do
+    #       let(:query) { '?status=submitted&sort_by=submitted_at&sort_direction=asc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('submitted'))
+    #         expect(records.first['submitted_at']).to be < records.second['submitted_at']
+    #       end
+    #     end
+
+    #     context 'when direction is `descending`' do
+    #       let(:query) { '?status=submitted&sort_by=submitted_at&sort_direction=desc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('submitted'))
+    #         expect(records.first['submitted_at']).to be > records.second['submitted_at']
+    #       end
+    #     end
+    #   end
+    # end
+
+    # context 'when status is `returned`' do
+    #   context 'when sorting by `submitted_at`' do
+    #     context 'when direction is `ascending`' do
+    #       let(:query) { '?status=returned&sort_by=submitted_at&sort_direction=asc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('returned'))
+    #         expect(records.first['submitted_at']).to be < records.second['submitted_at']
+    #       end
+    #     end
+
+    #     context 'when direction is `descending`' do
+    #       let(:query) { '?status=returned&sort_by=submitted_at&sort_direction=desc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('returned'))
+    #         expect(records.first['submitted_at']).to be > records.second['submitted_at']
+    #       end
+    #     end
+    #   end
+
+    #   context 'when sorting by `returned_at`' do
+    #     context 'when direction is ascending' do
+    #       let(:query) { '?status=returned&sort_by=returned_at&sort_direction=asc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('returned'))
+    #         expect(records.first['returned_at']).to be < records.second['returned_at']
+    #       end
+    #     end
+
+    #     context 'when direction is descending' do
+    #       let(:query) { '?status=returned&sort_by=returned_at&sort_direction=desc' }
+
+    #       it 'the records are returned in ascending order' do
+    #         expect(records.size).to be(2)
+
+    #         expect(records.pluck('status')).to all(eq('returned'))
+    #         expect(records.first['returned_at']).to be > records.second['returned_at']
+    #       end
+    #     end
+    #   end
+    # end
+  end
+end

--- a/spec/models/sorting_spec.rb
+++ b/spec/models/sorting_spec.rb
@@ -28,13 +28,5 @@ describe Sorting do
         expect(scope).to have_received(:order).with({ reviewed_at: :asc })
       end
     end
-
-    context 'when nil sort_by specified' do
-      let(:params) { { sort_by: nil, sort_direction: nil } }
-
-      it 'orders by defaults submitted_at:desc' do
-        expect(scope).to have_received(:order).with({ submitted_at: :desc })
-      end
-    end
   end
 end

--- a/spec/models/sorting_spec.rb
+++ b/spec/models/sorting_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Sorting do
+  subject(:sorting) { described_class.new(params) }
+
+  let(:params) { nil }
+
+  describe '#apply_to_scope' do
+    subject(:apply_to_scope) { sorting.apply_to_scope(scope) }
+
+    let(:scope) { class_double(CrimeApplication) }
+
+    before do
+      allow(scope).to receive(:order)
+      apply_to_scope
+    end
+
+    context 'with no params' do
+      it 'orders by defaults submitted_at:desc' do
+        expect(scope).to have_received(:order).with({ submitted_at: :desc })
+      end
+    end
+
+    context 'when valid sort_direction and sort_by specified' do
+      let(:params) { { sort_by: :reviewed_at, sort_direction: :asc } }
+
+      it 'applies specified sorting to scope' do
+        expect(scope).to have_received(:order).with({ reviewed_at: :asc })
+      end
+    end
+
+    context 'when nil sort_by specified' do
+      let(:params) { { sort_by: nil, sort_direction: nil } }
+
+      it 'orders by defaults submitted_at:desc' do
+        expect(scope).to have_received(:order).with({ submitted_at: :desc })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds the ability to sort searches for review, this is first PR with the basic column sorts. Others will follow for the outstanding sortable columns.

## Link to relevant ticket
[CRIMRE-142](https://dsdmoj.atlassian.net/browse/CRIMRE-142)

## Notes for reviewer / how to test


[CRIMRE-142]: https://dsdmoj.atlassian.net/browse/CRIMRE-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ