### PR TITLE
CRIMAP-265 Supersede parent of resubmissions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c7febd8d13df6522d19971d0a37db0095abb45b2
+  revision: 46dd417bbb3a30d5b8ecdd0652e6f0d7a0dd86b2
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
@@ -80,7 +80,7 @@ GEM
     brakeman (5.4.0)
     builder (3.2.4)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -2,26 +2,22 @@ class CrimeApplication < ApplicationRecord
   has_one :return_details, dependent: :destroy
 
   attr_readonly :application, :submitted_at, :id
+  enum status: Types::ApplicationStatus.mapping
 
-  before_validation :set_id, on: :create
-
-  validates :status, presence: true, inclusion: { in: Types::APPLICATION_STATUSES }
+  before_validation :shift_payload_attributes, on: :create
 
   scope :by_status, ->(status) { where(status:) }
   scope :by_office, lambda { |office_code|
     where("application->'provider_details'->>'office_code' = ?", office_code)
   }
 
-  def returned?
-    !returned_at.nil?
-  end
-
   private
 
-  def set_id
+  def shift_payload_attributes
     return unless id.nil?
     return unless application
 
     self.id = application.fetch('id')
+    self.submitted_at = application.fetch('submitted_at')
   end
 end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -13,6 +13,8 @@ module Operations
     def call
       app = CrimeApplication.create!(application: payload)
 
+      SupersedeApplication.new(application_id: parent_id).call if parent_id
+
       { id: app.id }
     end
 
@@ -23,6 +25,10 @@ module Operations
       return if schema_validator.valid?
 
       raise LaaCrimeSchemas::Errors::ValidationError, schema_validator.fully_validate
+    end
+
+    def parent_id
+      payload.fetch('parent_id', nil)
     end
   end
 end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -11,11 +11,13 @@ module Operations
     end
 
     def call
-      app = CrimeApplication.create!(application: payload)
+      CrimeApplication.transaction do
+        app = CrimeApplication.create!(application: payload)
 
-      SupersedeApplication.new(application_id: parent_id).call if parent_id
+        SupersedeApplication.new(application_id: parent_id).call if parent_id
 
-      { id: app.id }
+        { id: app.id }
+      end
     end
 
     private

--- a/app/services/operations/supersede_application.rb
+++ b/app/services/operations/supersede_application.rb
@@ -1,0 +1,14 @@
+module Operations
+  class SupersedeApplication
+    attr_reader :application_id
+
+    def initialize(application_id:)
+      @application_id = application_id
+    end
+
+    def call
+      app = CrimeApplication.returned.find_by(id: application_id)
+      app.try(:superseded!)
+    end
+  end
+end

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'create application' do
+RSpec.describe 'return application' do
   let(:application) do
     CrimeApplication.create!(
       application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
@@ -69,7 +69,7 @@ RSpec.describe 'create application' do
 
     context 'with a returned application' do
       before do
-        application.update!(returned_at: 1.week.ago)
+        application.update!(status: :returned, returned_at: 1.week.ago)
       end
 
       it 'does not record the return details' do

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -36,6 +36,12 @@ describe CrimeApplication do
       it 'has the same id as the document' do
         expect(application).not_to be_nil
       end
+
+      it 'has the same `submitted_at` as the document' do
+        expect(
+          application.submitted_at
+        ).to eq(application_attributes['submitted_at'])
+      end
     end
   end
 end

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -46,7 +46,7 @@ describe Operations::ReturnApplication do
       end
 
       context 'when application has already been returned' do
-        before { application.update(returned_at: 1.day.ago) }
+        before { application.update(status: :returned, returned_at: 1.day.ago) }
 
         it 'raises AlreadyReturned error' do
           expect { call }.to raise_error Errors::AlreadyReturned

--- a/spec/services/operations/supersede_application_spec.rb
+++ b/spec/services/operations/supersede_application_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Operations::SupersedeApplication do
+  subject { described_class.new(application_id:) }
+
+  let(:application_id) { '47a93336-7da6-48ec-b139-808ddd555a41' }
+
+  describe '#call' do
+    before do
+      CrimeApplication.create(
+        application: JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read),
+        status: :returned,
+      )
+    end
+
+    context 'when an application is found' do
+      let(:application) { CrimeApplication.find(application_id) }
+
+      it 'sets the status to `superseded`' do
+        expect { subject.call }.to change { application.reload.status }.from('returned').to('superseded')
+      end
+    end
+
+    context 'when an application is not found' do
+      let(:application_id) { '0c6551ef-88fe-403f-aa35-79268cba66b0' }
+
+      it 'does not raise any error' do
+        expect { subject.call }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
On resubmission of a returned application, this new submission is technically a brand new application, but points to the returned one through an attribute `parent_id`.

With this information, when a resubmission (meaning  `parent_id` is not nil) is received and successfully validated and persisted, the “parent“ application is then marked as superseded, by changing its status.

Additionally in this PR some minor tweaks:

- shift the `submitted_at` attribute from the payload to the table column so both are always in sync.

- use an enum for the `status` attribute on the CrimeApplication records, so no longer need to have a separate presence/inclusion validation, and also we gain methods like `returned?` and scopes.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-265

## Notes for reviewer / how to test
Note: in some places the statuses are coming from `Types::APPLICATION_STATUSES` which now we could replace with `CrimeApplication.statuses.keys` but didn't want to change this for now, as perhaps is not so immediately clear as using the Types constant directly. Couldn't made my mind. We can change it if we feel like it.