### PR TITLE
CRIMRE-143 Sort by applicant_name and reference

### DIFF
--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -10,10 +10,11 @@ class Sorting
   }.freeze
 
   SORT_COLUMNS = {
-    reference: :reference,
-    submitted_at: :submitted_at,
-    returned_at: :returned_at,
-    reviewed_at: :reviewed_at,
+    applicant_name: [:applicant_last_name, :applicant_first_name],
+    reference: [:reference],
+    returned_at: [:returned_at],
+    reviewed_at: [:reviewed_at],
+    submitted_at: [:submitted_at]
   }.freeze
 
   DEFAULT_SORT_BY = :submitted_at
@@ -23,12 +24,16 @@ class Sorting
   attribute :sort_direction, :string, default: DEFAULT_DIRECTION
 
   def apply_to_scope(scope)
-    scope.order({ column => direction })
+    scope.order(**order_params)
   end
 
   private
 
-  def column
+  def order_params
+    column_names.index_with { direction }
+  end
+
+  def column_names
     SORT_COLUMNS.fetch(sort_by.to_sym)
   end
 

--- a/db/migrate/20230127125227_add_sort_indexes_to_crime_applications.rb
+++ b/db/migrate/20230127125227_add_sort_indexes_to_crime_applications.rb
@@ -1,0 +1,25 @@
+class AddSortIndexesToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    change_table :crime_applications do |t|
+      t.virtual(
+        :reference,
+        type: :integer, as: "(application->>'reference')::int", stored: true
+      )
+      
+      t.virtual(
+        :applicant_first_name,
+        type: :string, as: "(application#>>'{client_details,applicant,first_name}')", stored: true
+      )
+
+      t.virtual(
+        :applicant_last_name,
+        type: :string, as: "(application#>>'{client_details,applicant,last_name}')", stored: true
+      )
+
+      t.change :status, :string
+    end
+
+    add_index :crime_applications, :reference
+    add_index :crime_applications, [:applicant_last_name, :applicant_first_name], name: 'index_crime_applications_on_applicant_name'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_091219) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_27_125227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,12 +18,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_091219) do
     t.jsonb "application"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "status", default: "submitted", null: false
+    t.string "status", default: "submitted", null: false
     t.datetime "submitted_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "returned_at", precision: nil
     t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (application ->> 'reference'::text)))", stored: true
     t.datetime "reviewed_at", precision: nil
     t.string "review_status"
+    t.virtual "reference", type: :integer, as: "((application ->> 'reference'::text))::integer", stored: true
+    t.virtual "applicant_first_name", type: :string, as: "(application #>> '{client_details,applicant,first_name}'::text[])", stored: true
+    t.virtual "applicant_last_name", type: :string, as: "(application #>> '{client_details,applicant,last_name}'::text[])", stored: true
+    t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
+    t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["searchable_text"], name: "index_crime_applications_on_searchable_text", using: :gin
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
     t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }

--- a/spec/models/sorting_spec.rb
+++ b/spec/models/sorting_spec.rb
@@ -28,5 +28,15 @@ describe Sorting do
         expect(scope).to have_received(:order).with({ reviewed_at: :asc })
       end
     end
+
+    context 'with a compound sort' do
+      let(:params) { { sort_by: :applicant_name } }
+
+      it 'orders by both columns' do
+        expect(scope).to have_received(:order).with(
+          { applicant_last_name: :desc, applicant_first_name: :desc, }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

Allow for sorting by applicant name and reference.
Adds reference, applicant first name, and applicant last names as virtual attributes for indexing.

## Link to relevant ticket

[CRIMRE-143](https://dsdmoj.atlassian.net/browse/CRIMRE-143)

## Notes for reviewer / how to test


[CRIMRE-143]: https://dsdmoj.atlassian.net/browse/CRIMRE-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ