### PR TITLE
CRIMRE-164 ensure search vector and query use same configuration

### DIFF
--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -57,7 +57,6 @@ class SearchFilter
   end
 
   def filter_search_text(scope)
-    query_text = search_text.split.join('&')
-    scope.where('searchable_text @@ to_tsquery(?)', query_text)
+    scope.where("searchable_text @@ plainto_tsquery('english', ?)", search_text)
   end
 end

--- a/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'search with text' do
   let(:records) { JSON.parse(response.body).fetch('records') }
 
   before do
-    details = %i[John Deere 1010 Ken John 1020 Jonathan Deere 1030].each_slice(3)
+    details = %i[Jenni Deere 1010 David Brown 1020 Jenny Deere 1030].each_slice(3)
     CrimeApplication.insert_all(
       details.map do |first_name, last_name, reference|
         {
@@ -34,15 +34,15 @@ RSpec.describe 'search with text' do
   end
 
   context 'when first name is searched' do
-    let(:search) { { search_text: 'John' } }
+    let(:search) { { search_text: 'Jenni' } }
 
-    it 'shows results that match the first name' do
-      expect(records.pluck('reference')).to match([1010, 1020])
+    it 'shows results that match the first name or alternative spelling' do
+      expect(records.pluck('reference')).to match([1010, 1030])
     end
   end
 
   context 'when reference is included' do
-    let(:search) { { search_text: 'Deere 1030' } }
+    let(:search) { { search_text: 'Jenni Deere 1030' } }
 
     it 'shows results that match the reference name' do
       expect(records.pluck('reference')).to match([1030])
@@ -58,10 +58,18 @@ RSpec.describe 'search with text' do
   end
 
   context 'when first and last name are searched' do
-    let(:search) { { search_text: 'John Deere' } }
+    let(:search) { { search_text: 'Jenni Deere' } }
 
     it 'shows results that match the full name' do
-      expect(records.pluck('reference')).to match([1010])
+      expect(records.pluck('reference')).to match([1010, 1030])
+    end
+  end
+
+  context 'when a name is indexed differently' do
+    let(:search) { { search_text: 'Jenny', status: ['submitted'] } }
+
+    it 'shows results that match the full name' do
+      expect(records.pluck('reference')).to match([1010, 1030])
     end
   end
 end


### PR DESCRIPTION
## Description of change

Ensure text search vector and query use the same config.

## Link to relevant ticket

[CRIMRE-164](https://dsdmoj.atlassian.net/browse/CRIMRE-164)

## Notes for reviewer / how to test

Testing locally would require updating pg_config to use a different dictionary to the one used for the vector. The revised code for the query from this PR was tested on staging via the console and confirmed to work.


[CRIMRE-164]: https://dsdmoj.atlassian.net/browse/CRIMRE-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ