### PR TITLE
Prepare datastore for JWT auth

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,6 +6,10 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa-criminal-applications-datastore
 
+# JWT auth API consumers shared secrets
+API_AUTH_SECRET_APPLY=
+API_AUTH_SECRET_REVIEW=
+
 # ElasticMQ endpoint, only used for local development/tests
 # In k8s cloud environments, real AWS SQS is used instead
 LOCAL_ELASTICMQ_URL=http://localhost:9324

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,9 @@ gem 'mail', '< 2.8.0'
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
 
+gem 'simple-jwt-auth',
+    github: 'ministryofjustice/simple-jwt-auth'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem 'grape', '~> 1.6.2'
 gem 'grape-entity', '~> 0.10.2'
 gem 'kaminari-activerecord'
 
+# Datastore API authentication
+gem 'moj-simple-jwt-auth', '0.0.1'
+
 # SQS message processor
 gem 'aws-sdk-sqs'
 gem 'shoryuken'
@@ -21,9 +24,6 @@ gem 'mail', '< 2.8.0'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas'
-
-gem 'simple-jwt-auth',
-    github: 'ministryofjustice/simple-jwt-auth'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
       dry-struct
       json-schema (~> 3.0.0)
 
-GIT
-  remote: https://github.com/ministryofjustice/simple-jwt-auth.git
-  revision: 174ad91cd1d9ba13e990ab98be2e9db21dc8b625
-  specs:
-    simple-jwt-auth (0.0.1)
-      json
-      jwt
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -172,6 +164,9 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    moj-simple-jwt-auth (0.0.1)
+      json
+      jwt
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -318,6 +313,7 @@ DEPENDENCIES
   kaminari-activerecord
   laa-criminal-legal-aid-schemas!
   mail (< 2.8.0)
+  moj-simple-jwt-auth (= 0.0.1)
   pg (~> 1.4)
   pry
   puma
@@ -328,7 +324,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoryuken
-  simple-jwt-auth!
   simplecov
   webmock
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/simple-jwt-auth.git
-  revision: 8c5e442d0fc242cc785f07cabd69b3af89d1e11b
+  revision: 174ad91cd1d9ba13e990ab98be2e9db21dc8b625
   specs:
     simple-jwt-auth (0.0.1)
       json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,14 @@ GIT
       dry-struct
       json-schema (~> 3.0.0)
 
+GIT
+  remote: https://github.com/ministryofjustice/simple-jwt-auth.git
+  revision: 8c5e442d0fc242cc785f07cabd69b3af89d1e11b
+  specs:
+    simple-jwt-auth (0.0.1)
+      json
+      jwt
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -149,6 +157,7 @@ GEM
     json (2.6.3)
     json-schema (3.0.0)
       addressable (>= 2.8)
+    jwt (2.7.0)
     kaminari-activerecord (1.2.2)
       activerecord
       kaminari-core (= 1.2.2)
@@ -319,6 +328,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoryuken
+  simple-jwt-auth!
   simplecov
   webmock
 

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -3,7 +3,7 @@ module Datastore
     format :json
     prefix :api
 
-    # auth :jwt unless Rails.env.test?
+    # auth :jwt
 
     mount V2::Health
     mount V2::Applications

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -3,6 +3,8 @@ module Datastore
     format :json
     prefix :api
 
+    # auth :jwt unless Rails.env.test?
+
     mount V2::Health
     mount V2::Applications
     mount V2::Searches

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -1,0 +1,13 @@
+require 'simple_jwt_auth'
+
+SimpleJwtAuth.configure do |config|
+  config.logger = Logger.new(STDOUT)
+  config.logger.level = Logger::DEBUG
+
+  # A map of consumers of the API and their secrets
+  # On kubernetes, secrets are created by terraform
+  config.secrets_config = {
+    'crime-apply' => ENV.fetch('API_AUTH_SECRET_APPLY', nil),
+    'crime-review' => ENV.fetch('API_AUTH_SECRET_REVIEW', nil),
+  }
+end

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -67,3 +67,13 @@ spec:
               secretKeyRef:
                 name: rds-instance
                 key: url
+          - name: API_AUTH_SECRET_APPLY
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: crime_apply
+          - name: API_AUTH_SECRET_REVIEW
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: crime_review


### PR DESCRIPTION
## Description of change
Merging this will not enable JWT or change any functionality on the datastore, as it is not enabled yet (the line that would otherwise enable this is commented out on purpose for the easy testing in localhost).

Once the `auth :jwt` is enabled, it will make use of a little middleware introduced in the `simple-jwt-auth` gem to perform verification of the bearer token.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-273

## Notes for reviewer / how to test
If wanted to test locally, a corresponding PR will be raised in the apply repo soon, in order to have an end to end, locally-testable demo.