### PR TITLE
Enable JWT authentication

### DIFF
--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -3,7 +3,8 @@ module Datastore
     format :json
     prefix :api
 
-    # auth :jwt
+    # JWT auth middleware from `moj-simple-jwt-auth` gem
+    auth :jwt
 
     mount V2::Health
     mount V2::Applications

--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -6,8 +6,6 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: ingress-staging-laa-criminal-applications-datastore-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: secrets-staging
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /.well-known/security.txt {
         auth_basic off;


### PR DESCRIPTION
## Description of change
Once merged, all API endpoints will require a JWT bearer token. There are corresponding PRs on Apply and Review repos for this as well.

Also once merged, the http basic auth will be disabled at the ingress on staging.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-277
