### PR TITLE
Set a more sensible default for ENV variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,8 +7,10 @@
 DATABASE_URL=postgresql://postgres@localhost/laa-criminal-applications-datastore
 
 # JWT auth API consumers shared secrets
-API_AUTH_SECRET_APPLY=
-API_AUTH_SECRET_REVIEW=
+# Value does not matter, as long as it is not blank or nil,
+# and the consumers have the same env value
+API_AUTH_SECRET_APPLY=foobar
+API_AUTH_SECRET_REVIEW=foobar
 
 # ElasticMQ endpoint, only used for local development/tests
 # In k8s cloud environments, real AWS SQS is used instead

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -1,8 +1,9 @@
 require 'simple_jwt_auth'
 
 SimpleJwtAuth.configure do |config|
-  config.logger = Logger.new(STDOUT)
-  config.logger.level = Logger::DEBUG
+  # Log level inherited from Rails logger, by default
+  # `debug` in development/test and `info` in production
+  config.logger = Rails.logger
 
   # A map of consumers of the API and their secrets
   # On kubernetes, secrets are created by terraform


### PR DESCRIPTION
## Description of change
With openssl >= 3.0.0 you need to have something in those secrets. Nil or empty string will produce an error.

With openssl < 3.0.0 a nil value will blow up but funnily enough not an empty string.

To avoid confusion and edge cases with the openssl version installed in each system, we set a default dummy value, so developers don't need to set their own in their `.local` files.

Also, tune the logger.
