### PR TITLE
First incarnation of SNS events publishing

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,6 +16,11 @@ API_AUTH_SECRET_REVIEW=foobar
 # In k8s cloud environments, real AWS SQS is used instead
 LOCAL_ELASTICMQ_URL=http://localhost:9324
 
+# An SNS faker service can be run locally to receive events.
+# Configure the faker with the corresponding host:port and topic
+# LOCAL_SNS_FAKER_URL=http://localhost:9911
+# EVENTS_SNS_TOPIC_ARN=events_sns
+
 # MAAT SQS queue URL (this will point to AWS on k8s)
 SQS_MAAT_QUEUE_URL="${LOCAL_ELASTICMQ_URL}/submitted_applications_for_maat"
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,12 @@ gem 'kaminari-activerecord'
 # Datastore API authentication
 gem 'moj-simple-jwt-auth', '0.0.1'
 
-# SQS message processor
+# SNS/SQS messaging
+gem 'aws-sdk-sns'
 gem 'aws-sdk-sqs'
+
+# NOTE: we can probably remove this gem in favor of a simpler
+# approach to messaging. Can be done as a separate PR.
 gem 'shoryuken'
 
 gem 'laa-criminal-legal-aid-schemas',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 2530eda6f3b1c89bfa7f18230bba684b6d6e3419
+  revision: 79de69687adb7f596206e3835f5b77ba867a99ea
   specs:
     laa-criminal-legal-aid-schemas (0.1.1)
       dry-struct
@@ -78,12 +78,15 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.711.0)
+    aws-partitions (1.712.0)
     aws-sdk-core (3.170.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
+    aws-sdk-sns (1.60.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-sqs (1.53.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
@@ -265,7 +268,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.26.0)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.17.0)
+    rubocop-capybara (2.17.1)
       rubocop (~> 1.41)
     rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
@@ -290,7 +293,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     thor (1.2.1)
-    timeout (0.3.1)
+    timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -307,6 +310,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-sns
   aws-sdk-sqs
   brakeman
   debug

--- a/app/services/events/base_event.rb
+++ b/app/services/events/base_event.rb
@@ -1,0 +1,26 @@
+module Events
+  class BaseEvent
+    attr_reader :crime_application
+
+    def initialize(crime_application)
+      @crime_application = crime_application
+    end
+
+    # :nocov:
+    def name
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+
+    # Can be overridden in subclasses if required
+    def message
+      crime_application.application
+    end
+
+    # Convenience method as currently we only have
+    # one SNS topic and one publisher
+    def publish
+      Messaging::EventsPublisher.publish(self)
+    end
+  end
+end

--- a/app/services/events/returned.rb
+++ b/app/services/events/returned.rb
@@ -1,0 +1,7 @@
+module Events
+  class Returned < BaseEvent
+    def name
+      'review.returned'.freeze
+    end
+  end
+end

--- a/app/services/events/submission.rb
+++ b/app/services/events/submission.rb
@@ -1,0 +1,7 @@
+module Events
+  class Submission < BaseEvent
+    def name
+      'apply.submission'.freeze
+    end
+  end
+end

--- a/app/services/messaging/events_publisher.rb
+++ b/app/services/messaging/events_publisher.rb
@@ -1,0 +1,62 @@
+module Messaging
+  class EventsPublisher
+    def self.publish(event)
+      new.publish(event)
+    end
+
+    def publish(event)
+      return false unless enabled?
+
+      Rails.logger.debug { "==> Publishing event `#{event.name}` to SNS topic `#{topic_arn}`" }
+
+      client.publish(
+        topic_arn: topic_arn,
+        message: event.message.to_json,
+        message_attributes: {
+          event_name: {
+            data_type: 'String',
+            string_value: event.name,
+          },
+        }
+      )
+    end
+
+    def enabled?
+      topic_arn.present?
+    end
+
+    private
+
+    def client
+      @client ||= Aws::SNS::Client.new(
+        **{
+          endpoint:,
+          access_key_id:,
+          secret_access_key:,
+          region:
+        }.compact_blank
+      )
+    end
+
+    def topic_arn
+      ENV.fetch('EVENTS_SNS_TOPIC_ARN', nil)
+    end
+
+    def access_key_id
+      ENV.fetch('EVENTS_SNS_TOPIC_KEY_ID', nil)
+    end
+
+    def secret_access_key
+      ENV.fetch('EVENTS_SNS_TOPIC_SECRET', nil)
+    end
+
+    def region
+      ENV.fetch('EVENTS_SNS_TOPIC_REGION', 'eu-west-2')
+    end
+
+    # Endpoint is only used to fake a local SNS service
+    def endpoint
+      ENV.fetch('LOCAL_SNS_FAKER_URL', nil)
+    end
+  end
+end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -12,12 +12,14 @@ module Operations
 
     def call
       CrimeApplication.transaction do
-        app = CrimeApplication.create!(application: payload)
-
+        @app = CrimeApplication.create!(application: payload)
         SupersedeApplication.new(application_id: parent_id).call if parent_id
-
-        { id: app.id }
       end
+
+      # Publish event notification to the SNS topic
+      Events::Submission.new(@app).publish
+
+      { id: @app.id }
     end
 
     private

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -77,3 +77,18 @@ spec:
               secretKeyRef:
                 name: api-auth-secrets
                 key: crime_review
+          - name: EVENTS_SNS_TOPIC_ARN
+            valueFrom:
+              secretKeyRef:
+                name: application-events-sns-topic
+                key: topic_arn
+          - name: EVENTS_SNS_TOPIC_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: application-events-sns-topic
+                key: access_key_id
+          - name: EVENTS_SNS_TOPIC_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: application-events-sns-topic
+                key: secret_access_key

--- a/spec/api/datastore/v2/create_application_spec.rb
+++ b/spec/api/datastore/v2/create_application_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'create application' do
     let(:record) { instance_double(CrimeApplication, id: application_id) }
     let(:payload) { LaaCrimeSchemas.fixture(1.0).read }
 
+    let(:submission_event) { instance_double(Events::Submission, publish: true) }
+
     context 'with a valid request' do
       before do
         allow(CrimeApplication).to receive(:create!).with(
@@ -27,6 +29,10 @@ RSpec.describe 'create application' do
         allow(
           Operations::SupersedeApplication
         ).to receive(:new).and_return(double.as_null_object)
+
+        allow(
+          Events::Submission
+        ).to receive(:new).with(record).and_return(submission_event)
 
         api_request
       end
@@ -49,6 +55,12 @@ RSpec.describe 'create application' do
         expect(Operations::SupersedeApplication).not_to have_received(:new)
       end
 
+      it 'publishes a submission event' do
+        expect(
+          submission_event
+        ).to have_received(:publish)
+      end
+
       context 'when is a resubmission' do
         let(:payload) { JSON.dump(JSON.parse(super()).merge('parent_id' => '12345')) }
 
@@ -56,6 +68,12 @@ RSpec.describe 'create application' do
           expect(
             Operations::SupersedeApplication
           ).to have_received(:new).with(application_id: '12345')
+        end
+
+        it 'publishes a submission event' do
+          expect(
+            submission_event
+          ).to have_received(:publish)
         end
       end
     end
@@ -73,7 +91,7 @@ RSpec.describe 'create application' do
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'returns error informatation' do
+      it 'returns error information' do
         expect(response.body).to include('Record not unique')
       end
     end
@@ -99,7 +117,7 @@ RSpec.describe 'create application' do
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'returns error informatation' do
+      it 'returns error information' do
         expect(response.body).to include('failed_attribute')
       end
     end

--- a/spec/services/events/returned_spec.rb
+++ b/spec/services/events/returned_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Events::Returned do
+  let(:crime_application) do
+    instance_double(CrimeApplication, application: { foo: 'bar' })
+  end
+
+  it_behaves_like 'an event notification',
+                  name: 'review.returned',
+                  message: { foo: 'bar' }
+end

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Events::Submission do
+  let(:crime_application) do
+    instance_double(CrimeApplication, application: { foo: 'bar' })
+  end
+
+  it_behaves_like 'an event notification',
+                  name: 'apply.submission',
+                  message: { foo: 'bar' }
+end

--- a/spec/services/messaging/events_publisher_spec.rb
+++ b/spec/services/messaging/events_publisher_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe Messaging::EventsPublisher do
+  subject { described_class.new }
+
+  let(:event) do
+    instance_double(
+      Events::BaseEvent, name: 'test-event', message: { foo: 'bar' }
+    )
+  end
+
+  describe '.publish' do
+    let(:instance) { instance_double(described_class, publish: true) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'instantiates and call publish on the instance' do
+      described_class.publish(event)
+      expect(instance).to have_received(:publish)
+    end
+  end
+
+  describe '#publish' do
+    let(:sns_endpoint) { 'https://sns.eu-west-2.amazonaws.com' }
+
+    before do
+      allow(Rails.logger).to receive(:debug)
+
+      stub_const(
+        'ENV',
+        ENV.to_h.merge(
+          'EVENTS_SNS_TOPIC_ARN' => topic_arn,
+          'EVENTS_SNS_TOPIC_KEY_ID' => 'topic_key_id',
+          'EVENTS_SNS_TOPIC_SECRET' => 'topic_secret',
+        )
+      )
+    end
+
+    context 'when the publishing is enabled' do
+      let(:topic_arn) { 'topic_arn' }
+
+      before do
+        stub_request(:post, sns_endpoint)
+          .with(
+            body: hash_including(
+              'Action' => 'Publish',
+              'Message' => '{"foo":"bar"}',
+              'MessageAttributes.entry.1.Name' => 'event_name',
+              'MessageAttributes.entry.1.Value.DataType' => 'String',
+              'MessageAttributes.entry.1.Value.StringValue' => 'test-event',
+              'TopicArn' => 'topic_arn',
+            )
+          ).to_return(status: 201, body: '')
+      end
+
+      it 'publishes the event to the SNS topic' do
+        expect(subject.publish(event)).to be_truthy
+        expect(a_request(:post, sns_endpoint)).to have_been_made
+      end
+    end
+
+    context 'when the publishing is disabled' do
+      let(:topic_arn) { nil }
+
+      it 'does not publish the event and return false' do
+        expect(subject.publish(event)).to be(false)
+        expect(a_request(:post, sns_endpoint)).not_to have_been_made
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/events_shared_examples.rb
+++ b/spec/support/shared_examples/events_shared_examples.rb
@@ -1,0 +1,32 @@
+RSpec.shared_examples 'an event notification' do |options|
+  subject { described_class.new(crime_application) }
+
+  let(:name) { options[:name] }
+  let(:message) { options[:message] }
+
+  describe '#name' do
+    it 'has a name' do
+      expect(subject.name).to eq(name)
+    end
+  end
+
+  describe '#message' do
+    it 'has a message' do
+      expect(subject.message).to eq(message)
+    end
+  end
+
+  describe '#publish' do
+    before do
+      allow(Messaging::EventsPublisher).to receive(:publish)
+    end
+
+    it 'instantiates the publisher and publish itself' do
+      subject.publish
+
+      expect(
+        Messaging::EventsPublisher
+      ).to have_received(:publish).with(subject)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
We now have an initial infrastructure created in the namespace, with an SNS topic that receives notifications, and an SQS queue where these notifications are sent (for now no filter).

Idea being, datastore will publish a series of events to the SNS topic, and then one or more SQS subscribe to this topic and each receives the notifications that matters to them, based on an event filter.

Each event has a name. Only 2 are created in this PR as an initial example. Also each event can implement its own message/payload. For now both are the same, they publish the whole application JSON. But some events might require only a few attributes so this is possible.

I've left previous code for job processor with `shoryuken` but I don't think we need that anymore and is an overkill for our needs. The publishing to the topic is very fast so there is no need to enqueue this to be processed at a later time. It removes a lot of complexity. Idea is to clean up shoryuken unused code in a future PR unless we see a reason to leave it.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-268

## Notes for reviewer / how to test
It is possible to test certain things locally by using a fake SNS service which just listen and forwards messages to an SQS. In reality that is not enough and to test it properly we need to use the real SNS and SQS and all the setup done in cloud platform, as IAM users and access policies are involved.
Happy to do a step by step on how to test this and demo 😄 