### PR TITLE
Add default value for review status

### DIFF
--- a/db/migrate/20230216165844_set_default_review_status.rb
+++ b/db/migrate/20230216165844_set_default_review_status.rb
@@ -1,0 +1,9 @@
+class SetDefaultReviewStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :crime_applications, :review_status, false, Types::ReviewApplicationStatus['application_received']
+    change_column_default :crime_applications, :review_status, from: nil, to: Types::ReviewApplicationStatus['application_received']
+
+    add_index :crime_applications, [:review_status, :submitted_at]
+    add_index :crime_applications, [:review_status, :reviewed_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_27_125227) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_165844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,12 +23,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_27_125227) do
     t.datetime "returned_at", precision: nil
     t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (application ->> 'reference'::text)))", stored: true
     t.datetime "reviewed_at", precision: nil
-    t.string "review_status"
+    t.string "review_status", default: "application_received", null: false
     t.virtual "reference", type: :integer, as: "((application ->> 'reference'::text))::integer", stored: true
     t.virtual "applicant_first_name", type: :string, as: "(application #>> '{client_details,applicant,first_name}'::text[])", stored: true
     t.virtual "applicant_last_name", type: :string, as: "(application #>> '{client_details,applicant,last_name}'::text[])", stored: true
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
+    t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"
+    t.index ["review_status", "submitted_at"], name: "index_crime_applications_on_review_status_and_submitted_at"
     t.index ["searchable_text"], name: "index_crime_applications_on_searchable_text", using: :gin
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
     t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }

--- a/spec/api/datastore/v2/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/complete_application_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'complete application' do
     context 'with a submitted application' do
       it 'marks the application as complete' do
         expect { api_request }.to change { application.reload.review_status }
-          .from(nil).to('assessment_completed')
+          .from('application_received').to('assessment_completed')
       end
 
       it 'records reviewed_at' do


### PR DESCRIPTION
Add default value for review status
Add date sort indexes for review status

## Description of change
[CRIMRE-151](https://dsdmoj.atlassian.net/browse/CRIMRE-151)

## Link to relevant ticket

## Notes for reviewer / how to test

Review will shortly uses review_status exclusively for all search and table views. This sets a default value and adds indexing for sorting by dates. 


[CRIMRE-151]: https://dsdmoj.atlassian.net/browse/CRIMRE-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ