### PR TITLE
Add SNS message subject

### DIFF
--- a/app/services/messaging/events_publisher.rb
+++ b/app/services/messaging/events_publisher.rb
@@ -11,12 +11,10 @@ module Messaging
 
       client.publish(
         topic_arn: topic_arn,
+        subject: event.name,
         message: event.message.to_json,
         message_attributes: {
-          event_name: {
-            data_type: 'String',
-            string_value: event.name,
-          },
+          event_name: { data_type: 'String', string_value: event.name },
         }
       )
     end

--- a/spec/services/messaging/events_publisher_spec.rb
+++ b/spec/services/messaging/events_publisher_spec.rb
@@ -44,14 +44,16 @@ describe Messaging::EventsPublisher do
       before do
         stub_request(:post, sns_endpoint)
           .with(
-            body: hash_including(
+            body: {
               'Action' => 'Publish',
+              'Subject' => 'test-event',
               'Message' => '{"foo":"bar"}',
               'MessageAttributes.entry.1.Name' => 'event_name',
               'MessageAttributes.entry.1.Value.DataType' => 'String',
               'MessageAttributes.entry.1.Value.StringValue' => 'test-event',
               'TopicArn' => 'topic_arn',
-            )
+              'Version' => '2010-03-31',
+            }
           ).to_return(status: 201, body: '')
       end
 


### PR DESCRIPTION
## Description of change
Some endpoints, like http, don't receive the message attributes, but they do receive the subject, so the event name can be added here for redundancy.
