### PR TITLE
Tweaks to SNS publishing

### DIFF
--- a/app/services/events/base_event.rb
+++ b/app/services/events/base_event.rb
@@ -14,7 +14,7 @@ module Events
 
     # Can be overridden in subclasses if required
     def message
-      crime_application.application
+      { id: crime_application.id }
     end
 
     # Convenience method as currently we only have

--- a/app/services/messaging/events_publisher.rb
+++ b/app/services/messaging/events_publisher.rb
@@ -11,11 +11,13 @@ module Messaging
 
       client.publish(
         topic_arn: topic_arn,
-        subject: event.name,
-        message: event.message.to_json,
         message_attributes: {
           event_name: { data_type: 'String', string_value: event.name },
-        }
+        },
+        message: {
+          event_name: event.name,
+          data: event.message,
+        }.to_json
       )
     end
 

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -14,10 +14,10 @@ module Operations
       CrimeApplication.transaction do
         @app = CrimeApplication.create!(application: payload)
         SupersedeApplication.new(application_id: parent_id).call if parent_id
-      end
 
-      # Publish event notification to the SNS topic
-      Events::Submission.new(@app).publish
+        # Publish event notification to the SNS topic
+        Events::Submission.new(@app).publish
+      end
 
       { id: @app.id }
     end

--- a/app/services/operations/return_application.rb
+++ b/app/services/operations/return_application.rb
@@ -17,10 +17,10 @@ module Operations
           returned_at: return_details.created_at,
           reviewed_at: Time.zone.now
         )
-      end
 
-      # Publish event notification to the SNS topic
-      Events::Returned.new(application).publish
+        # Publish event notification to the SNS topic
+        Events::Returned.new(application).publish
+      end
 
       application
     end

--- a/spec/api/datastore/v2/create_application_spec.rb
+++ b/spec/api/datastore/v2/create_application_spec.rb
@@ -94,14 +94,17 @@ RSpec.describe 'create application' do
       it 'returns error information' do
         expect(response.body).to include('Record not unique')
       end
+
+      it 'does not publish a submission event' do
+        expect(
+          submission_event
+        ).not_to have_received(:publish)
+      end
     end
 
     context 'with a schema error' do
       before do
-        allow(CrimeApplication).to receive(:create!).with(
-          application: JSON.parse(payload)
-        ).and_return(record)
-
+        allow(CrimeApplication).to receive(:create!)
         api_request
       end
 

--- a/spec/services/events/returned_spec.rb
+++ b/spec/services/events/returned_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe Events::Returned do
   let(:crime_application) do
-    instance_double(CrimeApplication, application: { foo: 'bar' })
+    instance_double(CrimeApplication, id: 'f7b429cc')
   end
 
   it_behaves_like 'an event notification',
                   name: 'review.returned',
-                  message: { foo: 'bar' }
+                  message: { id: 'f7b429cc' }
 end

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe Events::Submission do
   let(:crime_application) do
-    instance_double(CrimeApplication, application: { foo: 'bar' })
+    instance_double(CrimeApplication, id: 'f7b429cc')
   end
 
   it_behaves_like 'an event notification',
                   name: 'apply.submission',
-                  message: { foo: 'bar' }
+                  message: { id: 'f7b429cc' }
 end

--- a/spec/services/messaging/events_publisher_spec.rb
+++ b/spec/services/messaging/events_publisher_spec.rb
@@ -46,8 +46,7 @@ describe Messaging::EventsPublisher do
           .with(
             body: {
               'Action' => 'Publish',
-              'Subject' => 'test-event',
-              'Message' => '{"foo":"bar"}',
+              'Message' => '{"event_name":"test-event","data":{"foo":"bar"}}',
               'MessageAttributes.entry.1.Name' => 'event_name',
               'MessageAttributes.entry.1.Value.DataType' => 'String',
               'MessageAttributes.entry.1.Value.StringValue' => 'test-event',


### PR DESCRIPTION
## Description of change
Moved the publishing of the events into the transaction as discussed.

Modified the message payload format and content. Only the ID of the application is now included in the payload. Also added the `event_name` to the message body as some subscribers might not get it from the message attributes.

Removed the subject, as it is not useful now that we have the event name in the message itself.

## Link to relevant ticket

## Notes for reviewer / how to test
