### PR TITLE
CRIMAP-289 Configure logging and filtering of PII

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 7.0.4'
 
 gem 'grape', '~> 1.7.0'
 gem 'grape-entity', '~> 0.10.2'
+gem 'grape_logging'
 gem 'kaminari-activerecord'
 
 # Exceptions notifications

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.714.0)
+    aws-partitions (1.715.0)
     aws-sdk-core (3.170.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -92,7 +92,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    brakeman (5.4.0)
+    brakeman (5.4.1)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
@@ -141,6 +141,9 @@ GEM
     grape-entity (0.10.2)
       activesupport (>= 3.0.0)
       multi_json (>= 1.3.2)
+    grape_logging (1.8.4)
+      grape
+      rack
     hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -256,14 +259,14 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
-    rubocop (1.45.1)
+    rubocop (1.46.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.26.0)
@@ -322,6 +325,7 @@ DEPENDENCIES
   dotenv-rails
   grape (~> 1.7.0)
   grape-entity (~> 0.10.2)
+  grape_logging
   kaminari-activerecord
   laa-criminal-legal-aid-schemas!
   moj-simple-jwt-auth (= 0.0.1)

--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -2,6 +2,8 @@ require 'laa_crime_schemas'
 
 module Datastore
   class Base < Grape::API
+    include Datastore::Concerns::Logging
+
     helpers Helpers::SortingParams
     helpers Helpers::PaginationParams
 

--- a/app/api/datastore/concerns/logging.rb
+++ b/app/api/datastore/concerns/logging.rb
@@ -1,0 +1,27 @@
+require 'grape_logging'
+
+module Datastore
+  module Concerns
+    module Logging
+      extend ActiveSupport::Concern
+
+      # :nocov:
+      included do
+        if Rails.env.production?
+          insert_before(
+            Grape::Middleware::Error,
+            GrapeLogging::Middleware::RequestLogger,
+            formatter: GrapeLogging::Formatters::Logstash.new,
+            include: [
+              # To log IP and UserAgent, uncomment next line
+              # GrapeLogging::Loggers::ClientEnv.new,
+              GrapeLogging::Loggers::FilterParameters.new,
+              GrapeLogging::Loggers::JwtIssuer.new,
+            ]
+          )
+        end
+      end
+      # :nocov:
+    end
+  end
+end

--- a/app/lib/grape_logging/loggers/jwt_issuer.rb
+++ b/app/lib/grape_logging/loggers/jwt_issuer.rb
@@ -1,0 +1,9 @@
+module GrapeLogging
+  module Loggers
+    class JwtIssuer < GrapeLogging::Loggers::Base
+      def parameters(request, _)
+        { issuer: request.env['grape_jwt.payload'].try(:dig, 'iss') }
+      end
+    end
+  end
+end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,11 @@
 # notations and behaviors.
 Rails.application.config.filter_parameters += [
   :token, :_key, :crypt, :salt,
+  # Attributes relating to an application
+  # It does partial matching (i.e. `case_details` is covered by `details`)
   :application,
+  :details,
+  :first_name,
+  :last_name,
+  :searchable_text,
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       PORT: 3003
       DISABLE_HTTPS: "1"
       RAILS_SERVE_STATIC_FILES: "1"
+      API_AUTH_SECRET_APPLY: foobar
+      API_AUTH_SECRET_REVIEW: foobar
     ports:
       - "3003:3003"
     depends_on:

--- a/spec/lib/grape_logging/loggers/jwt_issuer_spec.rb
+++ b/spec/lib/grape_logging/loggers/jwt_issuer_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe GrapeLogging::Loggers::JwtIssuer do
+  let(:request) { instance_double(Rack::Request, env:) }
+  let(:response) { nil }
+
+  describe '#parameters' do
+    subject { described_class.new.parameters(request, response) }
+
+    context 'when there is `grape_jwt.payload` in the request env' do
+      let(:env) { { 'grape_jwt.payload' => { 'iss' => 'foobar' } } }
+
+      it 'returns the issuer' do
+        expect(subject).to eq(issuer: 'foobar')
+      end
+    end
+
+    context 'when there is no `grape_jwt.payload` in the request env' do
+      let(:env) { {} }
+
+      it 'returns a `nil` issuer' do
+        expect(subject).to eq(issuer: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Logs to stdout so other systems can route these logs to final destinations for viewing and long-term archival. For example this is needed to see the logs in Kibana.

Also, added a few more PII parameters to the filter. These are also used by Sentry when reporting exceptions.

NOTE: not using `lograge` as we did on Apply because that gem is only for Rails/Rails API, but Datastore is Grape API. Using an alternative gem which is similar and also produce a `logstash` format.

It is easy to extend to log more stuff by implementing a `GrapeLogging::Loggers` class. For instance I've implemented one for logging the JWT issuer of the request: `lib/grape_logging/loggers/jwt_issuer.rb`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-289

## Notes for reviewer / how to test
On local environments this new log stream to stdout can seen and tested by running the app in production mode, or by using docker-compose.
In our k8s namespaces, logs will output to stdout and can be accessed in Kibana.