### PR TITLE
CRIMAP-172 Use non-cluster specific domain

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -16,8 +16,19 @@ spec:
   tls:
   - hosts:
     - criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
+    - criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
   rules:
   - host: criminal-applications-datastore-staging.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: service-staging
+            port:
+              number: 80
+  - host: criminal-applications-datastore-staging.apps.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Description of change
As per documentation:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrating-from-live-1-domain-name.html

This is part of a broader ticket to use a custom domain for staging, however, for now this makes the service more resilient in case of cluster changes, until we have a production namespace and we set the proper final (and public) domains.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-172

## Notes for reviewer / how to test
Both domains should work. There is no redirection as this is an API consumed by other services, we want consumers migrating at their own pace to the new URL, and then we can remove the old one.