### PR TITLE
CRIMRE-184 add submitted_at to submission events

### DIFF
--- a/app/services/events/submission.rb
+++ b/app/services/events/submission.rb
@@ -3,5 +3,12 @@ module Events
     def name
       'apply.submission'.freeze
     end
+
+    def message
+      {
+        id: crime_application.id,
+        submitted_at: crime_application.submitted_at
+      }
+    end
   end
 end

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe Events::Submission do
   let(:crime_application) do
-    instance_double(CrimeApplication, id: 'f7b429cc')
+    instance_double(CrimeApplication, id: 'f7b429cc', submitted_at: DateTime.parse('2023-02-27'))
   end
 
   it_behaves_like 'an event notification',
                   name: 'apply.submission',
-                  message: { id: 'f7b429cc' }
+                  message: { id: 'f7b429cc', submitted_at: DateTime.parse('2023-02-27') }
 end


### PR DESCRIPTION
## Description of change

Add submitted_at to submission events.

## Link to relevant ticket

[CRIMRE-184](https://dsdmoj.atlassian.net/browse/CRIMRE-184)

## Notes for reviewer / how to test

This PR adds submitted_at to the message payload for submission events so that review can use the datastore's submitted_at for calculations and reporting. Without this change, review uses the sns notification timestamp, which could cause discrepancies between the two systems.


[CRIMRE-184]: https://dsdmoj.atlassian.net/browse/CRIMRE-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ