### PR TITLE
CRIMAP-38 Task to reassign apps to new office code

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,7 +1,7 @@
 class CrimeApplication < ApplicationRecord
   has_one :return_details, dependent: :destroy
 
-  attr_readonly :application, :submitted_at, :id
+  attr_readonly :submitted_at, :id
   enum status: Types::ApplicationStatus.mapping
   enum review_status: Types::ReviewApplicationStatus.mapping
 

--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -1,0 +1,22 @@
+namespace :applications do
+  # NOTE: this task can be deleted once it has been run
+  desc 'Reassign applications to new office code'
+  task reassign_office: :environment do
+    reassign_counter = 0
+    new_office_code = '1K022G'.freeze
+
+    puts "Reassigning applications to new office code #{new_office_code}"
+
+    CrimeApplication.find_each(batch_size: 30) do |record|
+      details = record.application.dig('provider_details')
+
+      if details['office_code'] != new_office_code
+        details['office_code'] = new_office_code
+        record.save(touch: false)
+        reassign_counter += 1
+      end
+    end
+
+    puts "#{reassign_counter} applications have been reassigned"
+  end
+end


### PR DESCRIPTION
## Description of change
Not to be merged until Apply PR is merged and tested. https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/292

This will reassign all applications in the datastore to an office belonging to the new provider we will be using on Apply staging after integrating with Portal staging.

Previous office code (`1A123B`) belongs to a mock provider, while we used SAMLmock on staging.

The only purpose of this is to keep going as if nothing happened, to not loose all the test applications we already have, needed for testing pagination, and sorting, etc.

To be able to do this more easily making use of active record, temporarily the `application` attribute has been removed from the `attr_readonly` declaration.

After this is merged, and the task is run, a follow-up PR will be raised to clean this up.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-38

## Notes for reviewer / how to test
