### PR TITLE
[CRIMRE-162] Add Postgresql citext module to applicant name fields

### DIFF
--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -23,11 +23,7 @@ class Sorting
   attribute :sort_direction, :string, default: DEFAULT_DIRECTION
 
   def apply_to_scope(scope)
-    if order_params[:applicant_first_name] || order_params[:applicant_last_name]
-      scope.order("lower(applicant_last_name) #{direction}, lower(applicant_first_name) #{direction}")
-    else
-      scope.order(**order_params)
-    end
+    scope.order(**order_params)
   end
 
   private

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -23,7 +23,11 @@ class Sorting
   attribute :sort_direction, :string, default: DEFAULT_DIRECTION
 
   def apply_to_scope(scope)
-    scope.order(**order_params)
+    if order_params[:applicant_first_name] || order_params[:applicant_last_name]
+      scope.order("lower(applicant_last_name) #{direction}, lower(applicant_first_name) #{direction}")
+    else
+      scope.order(**order_params)
+    end
   end
 
   private

--- a/db/migrate/20230321154839_enable_case_insensitive_applicant_name_fields.rb
+++ b/db/migrate/20230321154839_enable_case_insensitive_applicant_name_fields.rb
@@ -1,0 +1,13 @@
+class EnableCaseInsensitiveApplicantNameFields < ActiveRecord::Migration[7.0]
+  def up
+    enable_extension 'citext'
+    change_column :crime_applications, :applicant_first_name, :citext
+    change_column :crime_applications, :applicant_last_name, :citext
+  end
+
+  def down
+    change_column :crime_applications, :applicant_first_name, :string
+    change_column :crime_applications, :applicant_last_name, :string
+    disable_extension 'citext'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_16_165844) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_21_154839) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -25,8 +26,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_16_165844) do
     t.datetime "reviewed_at", precision: nil
     t.string "review_status", default: "application_received", null: false
     t.virtual "reference", type: :integer, as: "((application ->> 'reference'::text))::integer", stored: true
-    t.virtual "applicant_first_name", type: :string, as: "(application #>> '{client_details,applicant,first_name}'::text[])", stored: true
-    t.virtual "applicant_last_name", type: :string, as: "(application #>> '{client_details,applicant,last_name}'::text[])", stored: true
+    t.virtual "applicant_first_name", type: :citext, as: "(application #>> '{client_details,applicant,first_name}'::text[])", stored: true
+    t.virtual "applicant_last_name", type: :citext, as: "(application #>> '{client_details,applicant,last_name}'::text[])", stored: true
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"

--- a/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'search with text' do
   end
 
   context 'when first name is searched' do
-    let(:search) { { search_text: 'Jenni' } }
+    let(:search) { { search_text: 'jENNi' } }
 
     it 'shows results that match the first name or alternative spelling' do
       expect(records.pluck('reference')).to match([1010, 1030])
@@ -42,7 +42,7 @@ RSpec.describe 'search with text' do
   end
 
   context 'when reference is included' do
-    let(:search) { { search_text: 'Jenni Deere 1030' } }
+    let(:search) { { search_text: 'Jenni dEEre 1030' } }
 
     it 'shows results that match the reference name' do
       expect(records.pluck('reference')).to match([1030])
@@ -50,7 +50,7 @@ RSpec.describe 'search with text' do
   end
 
   context 'when last_name is searched' do
-    let(:search) { { search_text: 'Deere' } }
+    let(:search) { { search_text: 'DEERE' } }
 
     it 'shows results that match the last name' do
       expect(records.pluck('reference')).to match([1010, 1030])
@@ -58,7 +58,7 @@ RSpec.describe 'search with text' do
   end
 
   context 'when first and last name are searched' do
-    let(:search) { { search_text: 'Jenni Deere' } }
+    let(:search) { { search_text: 'jEnNi DEEre' } }
 
     it 'shows results that match the full name' do
       expect(records.pluck('reference')).to match([1010, 1030])

--- a/spec/api/datastore/v2/searches/sorting_spec.rb
+++ b/spec/api/datastore/v2/searches/sorting_spec.rb
@@ -24,12 +24,20 @@ RSpec.describe 'Sorting applications' do
   let(:applications) do
     [
       {
-        application: {},
+        application: {
+          client_details: {
+            applicant: { first_name: 'jim', last_name: 'Halpert' }
+          }
+        },
         status: 'submitted', submitted_at: 1.day.ago, returned_at: nil,
-        reviewed_at: nil
+        reviewed_at: nil,
       },
       {
-        application: {},
+        application: {
+          client_details: {
+            applicant: { first_name: 'Michael', last_name: 'Scott' }
+          }
+        },
         status: 'submitted', submitted_at: 2.days.ago, returned_at: nil,
         reviewed_at: nil
       },
@@ -39,7 +47,20 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: 8.days.ago
       },
       {
-        application: {},
+        application: {
+          client_details: {
+            applicant: { first_name: '', last_name: 'schrute' }
+          }
+        },
+        status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago,
+        reviewed_at: 5.days.ago
+      },
+      {
+        application: {
+          client_details: {
+            applicant: { first_name: 'Stanley', last_name: 'hudSon' }
+          }
+        },
         status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago,
         reviewed_at: 5.days.ago
       },
@@ -66,7 +87,7 @@ RSpec.describe 'Sorting applications' do
       end
     end
 
-    describe 'Setting sort params' do
+    describe 'setting sort params' do
       let(:sorting_params) do
         {
           'sort_direction' => 'ascending',
@@ -83,7 +104,7 @@ RSpec.describe 'Sorting applications' do
       end
     end
 
-    context 'when a search is performed' do
+    describe 'when a search is performed' do
       let(:search) do
         {
           status: %w[submitted returned]
@@ -100,7 +121,7 @@ RSpec.describe 'Sorting applications' do
           end
 
           it 'the records are returned in ascending order' do
-            expect(records_count).to be(4)
+            expect(records_count).to be(5)
 
             expect(records.first['submitted_at']).to be < records.second['submitted_at']
           end
@@ -115,7 +136,7 @@ RSpec.describe 'Sorting applications' do
           end
 
           it 'the records are returned in ascending order' do
-            expect(records.size).to be(4)
+            expect(records.size).to be(5)
 
             expect(records.first['submitted_at']).to be > records.second['submitted_at']
           end
@@ -132,7 +153,7 @@ RSpec.describe 'Sorting applications' do
           end
 
           it 'the records are returned in ascending order' do
-            expect(records_count).to be(4)
+            expect(records_count).to be(5)
 
             expect(records.first['reviewed_at']).to be < records.second['reviewed_at']
           end
@@ -149,6 +170,36 @@ RSpec.describe 'Sorting applications' do
           it 'the records are returned in ascending order' do
             expect(records.first['reviewed_at']).to be_nil
             expect(records.third['reviewed_at']).to be > records.fourth['reviewed_at']
+          end
+        end
+      end
+
+      context 'when sorting by `applicant_name`' do
+        context 'when direction is `ascending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'ascending',
+              'sort_by' => 'applicant_name'
+            }
+          end
+
+          it 'the records are returned in ascending order' do
+            expected_resultset = ['jim Halpert', 'Stanley hudSon', ' schrute', 'Michael Scott', ' ']
+            expect(records.pluck('applicant_name')).to eq expected_resultset
+          end
+        end
+
+        context 'when direction is `descending`' do
+          let(:sorting_params) do
+            {
+              'sort_direction' => 'descending',
+              'sort_by' => 'applicant_name'
+            }
+          end
+
+          it 'the records are returned in descending order' do
+            expected_resultset = [' ', 'Michael Scott', ' schrute', 'Stanley hudSon', 'jim Halpert']
+            expect(records.pluck('applicant_name')).to eq expected_resultset
           end
         end
       end

--- a/spec/api/datastore/v2/searches/sorting_spec.rb
+++ b/spec/api/datastore/v2/searches/sorting_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe 'Sorting applications' do
             applicant: { first_name: 'Stanley', last_name: 'hudSon' }
           }
         },
-        status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago,
-        reviewed_at: 5.days.ago
+        status: 'returned', submitted_at: 3.weeks.ago, returned_at: 13.days.ago,
+        reviewed_at: 16.days.ago
       },
     ]
   end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -44,4 +44,31 @@ describe CrimeApplication do
       end
     end
   end
+
+  describe '#applicant_name' do
+    context 'when created' do
+      subject!(:application) do
+        record = described_class.create!(valid_attributes)
+        record.reload
+      end
+
+      it 'is stored with correct case' do
+        applicant_name = [
+          application.applicant_first_name,
+          application.applicant_last_name
+        ].join(' ')
+
+        expect(applicant_name).to eq 'Kit Pound'
+      end
+
+      it 'is searchable with insensitive case' do
+        db_record = described_class.where(
+          applicant_first_name: 'kIt',
+          applicant_last_name: 'pOunD'
+        )
+
+        expect(db_record.first).to eq(application)
+      end
+    end
+  end
 end

--- a/spec/models/sorting_spec.rb
+++ b/spec/models/sorting_spec.rb
@@ -29,14 +29,12 @@ describe Sorting do
       end
     end
 
-    # Sorting strings on BSD/MacOSX results in undesirable behaviour
-    # https://dba.stackexchange.com/questions/106964/why-is-my-postgresql-order-by-case-insensitive
-    context 'with compound sort of applicant name' do
+    context 'with a compound applicant name sort' do
       let(:params) { { sort_by: :applicant_name } }
 
-      it 'orders using postgres lower function' do
+      it 'orders by both columns' do
         expect(scope).to have_received(:order).with(
-          'lower(applicant_last_name) desc, lower(applicant_first_name) desc'
+          { applicant_last_name: :desc, applicant_first_name: :desc, }
         )
       end
     end

--- a/spec/models/sorting_spec.rb
+++ b/spec/models/sorting_spec.rb
@@ -29,12 +29,14 @@ describe Sorting do
       end
     end
 
-    context 'with a compound sort' do
+    # Sorting strings on BSD/MacOSX results in undesirable behaviour
+    # https://dba.stackexchange.com/questions/106964/why-is-my-postgresql-order-by-case-insensitive
+    context 'with compound sort of applicant name' do
       let(:params) { { sort_by: :applicant_name } }
 
-      it 'orders by both columns' do
+      it 'orders using postgres lower function' do
         expect(scope).to have_received(:order).with(
-          { applicant_last_name: :desc, applicant_first_name: :desc, }
+          'lower(applicant_last_name) desc, lower(applicant_first_name) desc'
         )
       end
     end


### PR DESCRIPTION
## Description of change
Adds `citext` postgresql module to the `applicant_first_name` and `applicant_last_name` fields to allow case-insensitive ordering

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMRE-162

## Notes for reviewer / how to test
This seems to be an issue on MacOSX (requires verification on servers) due to the way character set collation is handled by the host operating system Postgres is installed on. ~~The workaround, to add the `lower()` function to the Order By clause may cause performance issues due to the way any indexes based on applicant_first_name/applicant_last_name would be ignored.~~

`citext` postgres module Inspired by https://github.com/ministryofjustice/laa-review-criminal-legal-aid/commit/134adaab21c2a3080e729625fff161d2e0cc72b2

See:
- https://dba.stackexchange.com/questions/106964/why-is-my-postgresql-order-by-case-insensitive

## Screenshots

#### BEFORE
<img width="1047" alt="Screenshot 2023-03-21 at 10 58 18" src="https://user-images.githubusercontent.com/47113046/226589007-de4fd3a2-ee42-47de-9352-1f2b5a87a7e9.png">


#### AFTER
<img width="1044" alt="Screenshot 2023-03-21 at 10 57 55" src="https://user-images.githubusercontent.com/47113046/226588997-ac30a6c0-1f88-4ca7-93e4-23613ebb1105.png">



