### PR TITLE
CRIMRE-248 update application review status to ready for assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,5 @@ At the moment these endpoints are:
 * `GET /api/v2/applications/{id}` get an application by its ID
 * `PUT /api/v2/applications/{id}/return` returns an application by its ID
 * `PUT /api/v2/applications/{id}/complete` marks an application as complete
+* `PUT /api/v2/applications/{id}/mark_as_ready` marks an application as ready for assessment
 * `GET /api/v2/health` checks connection to the database

--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -26,5 +26,9 @@ module Datastore
     rescue_from Errors::AlreadyCompleted do
       error!({ status: 409, error: 'Already Completed' }, 409)
     end
+
+    rescue_from Errors::AlreadyMarkedAsReady do
+      error!({ status: 409, error: 'Already marked as ready' }, 409)
+    end
   end
 end

--- a/app/api/datastore/v2/reviewing.rb
+++ b/app/api/datastore/v2/reviewing.rb
@@ -37,6 +37,21 @@ module Datastore
             end
           end
         end
+
+        desc 'Mark an application as ready for assessment.'
+        params do
+          requires :application_id, type: String, desc: 'Crime Application UUID'
+        end
+
+        route_param :application_id do
+          resource :mark_as_ready do
+            put do
+              mark_as_ready_params = declared(params).symbolize_keys
+              app = Operations::MarkAsReadyApplication.new(**mark_as_ready_params).call
+              present app, with: Datastore::Entities::CrimeApplication
+            end
+          end
+        end
       end
     end
   end

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -4,4 +4,7 @@ module Errors
 
   class AlreadyCompleted < StandardError
   end
+
+  class AlreadyMarkedAsReady < StandardError
+  end
 end

--- a/app/services/operations/mark_as_ready_application.rb
+++ b/app/services/operations/mark_as_ready_application.rb
@@ -1,0 +1,23 @@
+module Operations
+  class MarkAsReadyApplication
+    def initialize(application_id:)
+      @application = CrimeApplication.find(application_id)
+    end
+
+    def call
+      raise Errors::AlreadyMarkedAsReady if application.ready_for_assessment?
+      raise Errors::AlreadyCompleted if application.assessment_completed?
+      raise Errors::AlreadyReturned if application.returned?
+
+      application.update!(
+        review_status: Types::ReviewApplicationStatus['ready_for_assessment']
+      )
+
+      application
+    end
+
+    private
+
+    attr_reader :application
+  end
+end

--- a/spec/api/datastore/v2/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/complete_application_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'complete application' do
         application.update!(review_status: :assessment_completed, reviewed_at: 1.week.ago)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with a returned application' do
@@ -39,7 +39,7 @@ RSpec.describe 'complete application' do
         application.update!(status: :returned, reviewed_at: 1.week.ago)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with an unknown application' do

--- a/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'ready for assessment application' do
     end
 
     context 'with a submitted application' do
-      it 'marks the application as ready for' do
+      it 'marks the application as ready for assessment' do
         expect { api_request }.to change { application.reload.review_status }
           .from('application_received').to('ready_for_assessment')
       end
@@ -26,7 +26,7 @@ RSpec.describe 'ready for assessment application' do
         application.update!(review_status: :ready_for_assessment)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with a completed application' do
@@ -34,7 +34,7 @@ RSpec.describe 'ready for assessment application' do
         application.update!(review_status: :assessment_completed, reviewed_at: 1.week.ago)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with a returned application' do
@@ -42,7 +42,7 @@ RSpec.describe 'ready for assessment application' do
         application.update!(status: :returned, reviewed_at: 1.week.ago)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with an unknown application' do

--- a/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
@@ -1,29 +1,32 @@
 require 'rails_helper'
 
-RSpec.describe 'complete application' do
+RSpec.describe 'ready for assessment application' do
   let(:application) do
     CrimeApplication.create!(
       application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 
-  describe 'PUT /api/applications/application_id/complete' do
+  describe 'PUT /api/applications/application_id/mark_as_ready' do
     subject(:api_request) do
       put(
-        "/api/v2/applications/#{application.id}/complete"
+        "/api/v2/applications/#{application.id}/mark_as_ready"
       )
     end
 
     context 'with a submitted application' do
-      it 'marks the application as complete' do
+      it 'marks the application as ready for' do
         expect { api_request }.to change { application.reload.review_status }
-          .from('application_received').to('assessment_completed')
+          .from('application_received').to('ready_for_assessment')
+      end
+    end
+
+    context 'with a ready for assessment application' do
+      before do
+        application.update!(review_status: :ready_for_assessment)
       end
 
-      it 'records reviewed_at' do
-        expect { api_request }.to change { application.reload.reviewed_at }
-          .from(nil)
-      end
+      it_behaves_like 'raises a 409 error'
     end
 
     context 'with a completed application' do
@@ -45,7 +48,7 @@ RSpec.describe 'complete application' do
     context 'with an unknown application' do
       subject(:api_request) do
         put(
-          "/api/v2/applications/#{SecureRandom.uuid}/complete"
+          "/api/v2/applications/#{SecureRandom.uuid}/mark_as_ready"
         )
       end
 

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -83,10 +83,7 @@ RSpec.describe 'return application' do
         application.update!(review_status: :assessment_completed, reviewed_at: 1.week.ago)
       end
 
-      it 'raises a 409 error' do
-        api_request
-        expect(response).to have_http_status :conflict
-      end
+      it_behaves_like 'raises a 409 error'
     end
 
     context 'with an unknown application' do

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'return application' do
         application.update!(review_status: :assessment_completed, reviewed_at: 1.week.ago)
       end
 
-      it_behaves_like 'raises a 409 error'
+      it_behaves_like 'an error that raises a 409 status code'
     end
 
     context 'with an unknown application' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 require 'webmock/rspec'
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
+Dir[File.expand_path('shared_examples/*.rb', __dir__)].each { |f| require f }
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/shared_examples/409_error_spec.rb
+++ b/spec/shared_examples/409_error_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.shared_examples 'raises a 409 error' do
+RSpec.shared_examples 'an error that raises a 409 status code' do
   it 'raises a 409 error' do
     api_request
     expect(response).to have_http_status :conflict

--- a/spec/shared_examples/409_error_spec.rb
+++ b/spec/shared_examples/409_error_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'raises a 409 error' do
+  it 'raises a 409 error' do
+    api_request
+    expect(response).to have_http_status :conflict
+  end
+end


### PR DESCRIPTION
## Description of change

- Changes the review_state of the application in the Datastore to ready_for_assessment
- Action can only be completed once and an application can only transition from application_received to ready_for_assessment. An error is raised for all other statuses

## Link to relevant ticket
[CRIMRE-248](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-248)

## Notes for reviewer / how to test

Me and Tim discussed the investigation to add an index to enforce uniqueness of USN. I have left a comment in the [ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-248) explaining how this could be tackled


[CRIMRE-248]: https://dsdmoj.atlassian.net/browse/CRIMRE-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ