### PR TITLE
Fix flickering specs

### DIFF
--- a/spec/api/datastore/v2/list_applications_spec.rb
+++ b/spec/api/datastore/v2/list_applications_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'list applications' do
     describe 'status filter' do
       it 'defaults to show all statuses' do
         expect(records.size).to be(3)
-        expect(returned_statuses).to match_array %w[submitted returned superseded]
+        expect(returned_statuses).to match_array(%w[submitted returned superseded])
       end
 
       CrimeApplication.statuses.each_key do |status|

--- a/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_application_id_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe 'searches filter by id' do
 
   it 'defaults to showing all applications' do
     expect(records.count).to be 3
-    expect(records.pluck('resource_id')).to match(
-      CrimeApplication.pluck(:id)
-    )
+    expect(records.pluck('resource_id')).to match_array(CrimeApplication.pluck(:id))
   end
 
   describe 'filter by application_id_in' do
@@ -34,7 +32,7 @@ RSpec.describe 'searches filter by id' do
 
       it 'only shows results that match the application_id' do
         expect(records.count).to be 2
-        expect(records.pluck('resource_id')).to match(extant_ids)
+        expect(records.pluck('resource_id')).to match_array(extant_ids)
       end
     end
   end
@@ -51,9 +49,7 @@ RSpec.describe 'searches filter by id' do
       it 'only shows applications that are not in the excluded_ids' do
         expect(records.count).to be 1
 
-        expect(records.pluck('resource_id')).to match(
-          CrimeApplication.pluck(:id) - excluded_ids
-        )
+        expect(records.pluck('resource_id')).to match_array((CrimeApplication.pluck(:id) - excluded_ids))
       end
     end
   end

--- a/spec/api/datastore/v2/searches/filter_by_review_status_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_review_status_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe 'searches filter by review status' do
 
   it 'defaults to returning all statuses' do
     expect(records.count).to be 4
-    expect(records.pluck('review_status').uniq).to eq(
-      %w[application_received returned_to_provider ready_for_assessment]
-    )
+    expect(records.pluck('review_status').uniq).to match_array(%w[application_received returned_to_provider
+                                                                  ready_for_assessment])
   end
 
   describe 'filtering by "returned_to_provider"' do
@@ -42,7 +41,7 @@ RSpec.describe 'searches filter by review status' do
 
     it 'returns records with a status in statuses' do
       expect(records.count).to be 2
-      expect(records.pluck('review_status').uniq).to eq(%w[application_received ready_for_assessment])
+      expect(records.pluck('review_status').uniq).to match_array(%w[application_received ready_for_assessment])
     end
   end
 end

--- a/spec/api/datastore/v2/searches/filter_by_status_spec.rb
+++ b/spec/api/datastore/v2/searches/filter_by_status_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'searches filter by status' do
 
   it 'defaults to returning all statuses' do
     expect(records.count).to be 3
-    expect(records.pluck('status').uniq).to match_array(%w[submitted returned])
+    expect(records.pluck('status').uniq).to contain_exactly('submitted', 'returned')
   end
 
   describe 'filtering by "returned"' do
@@ -35,7 +35,7 @@ RSpec.describe 'searches filter by status' do
 
     it 'returns records with a status in statuses' do
       expect(records.count).to be 3
-      expect(records.pluck('status').uniq).to match_array(%w[submitted returned])
+      expect(records.pluck('status').uniq).to contain_exactly('submitted', 'returned')
     end
   end
 end

--- a/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
@@ -28,16 +28,14 @@ RSpec.describe 'search with text' do
 
   it 'defaults to showing all applications' do
     expect(records.count).to be 3
-    expect(records.pluck('resource_id')).to match(
-      CrimeApplication.pluck(:id)
-    )
+    expect(records.pluck('resource_id')).to match_array(CrimeApplication.pluck(:id))
   end
 
   context 'when first name is searched' do
     let(:search) { { search_text: 'jENNi' } }
 
     it 'shows results that match the first name or alternative spelling' do
-      expect(records.pluck('reference')).to match([1010, 1030])
+      expect(records.pluck('reference')).to contain_exactly(1010, 1030)
     end
   end
 
@@ -53,7 +51,7 @@ RSpec.describe 'search with text' do
     let(:search) { { search_text: 'DEERE' } }
 
     it 'shows results that match the last name' do
-      expect(records.pluck('reference')).to match([1010, 1030])
+      expect(records.pluck('reference')).to contain_exactly(1010, 1030)
     end
   end
 
@@ -61,7 +59,7 @@ RSpec.describe 'search with text' do
     let(:search) { { search_text: 'jEnNi DEEre' } }
 
     it 'shows results that match the full name' do
-      expect(records.pluck('reference')).to match([1010, 1030])
+      expect(records.pluck('reference')).to contain_exactly(1010, 1030)
     end
   end
 
@@ -69,7 +67,7 @@ RSpec.describe 'search with text' do
     let(:search) { { search_text: 'Jenny', status: ['submitted'] } }
 
     it 'shows results that match the full name' do
-      expect(records.pluck('reference')).to match([1010, 1030])
+      expect(records.pluck('reference')).to contain_exactly(1010, 1030)
     end
   end
 end


### PR DESCRIPTION
## Description of change

Update specs to ignore order unless important for the test.

## Link to relevant ticket

https://github.com/ministryofjustice/laa-criminal-applications-datastore/issues/65

## Notes for reviewer / how to test

The default sort_by on search is submitted_at. Records for the system specs use insert_all for speed. This means records sometimes have the same submitted_at and therefore the result order becomes inconsistent.
