### PR TITLE
Return additional required data for maat integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.0.1'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.2'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.3'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a43d0ec1eb0f2d51c8df74c068d71d5bf8a5f476
-  tag: v0.1.2
+  revision: d88d379896ed1acefc42e81285bcf8a4f18d966f
+  tag: v0.1.3
   specs:
     laa-criminal-legal-aid-schemas (0.1.2)
       dry-struct

--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -6,6 +6,7 @@ module Datastore
 
     helpers Helpers::SortingParams
     helpers Helpers::PaginationParams
+    helpers Helpers::Formatters
 
     rescue_from ActiveRecord::RecordNotFound do
       error!({ status: 404, error: 'Record not found' }, 404)

--- a/app/api/datastore/entities/maat/application.rb
+++ b/app/api/datastore/entities/maat/application.rb
@@ -2,13 +2,48 @@ module Datastore
   module Entities
     module Maat
       class Application < Grape::Entity
+        expose :id
+        expose :schema_version
         expose :reference
-        expose :applicant
+        expose :submitted_at, format_with: :iso8601
+        expose :date_stamp
+        expose :client_details
+        expose :provider_details
+        expose :case_details
+        expose :interests_of_justice
+        expose :ioj_passport
 
         private
 
-        def applicant
-          object.application&.dig('client_details', 'applicant')
+        def client_details
+          object.application&.dig('client_details')
+        end
+
+        def schema_version
+          1.0
+        end
+
+        def date_stamp
+          object.application&.dig('date_stamp')
+        end
+
+        def provider_details
+          object.application&.dig('provider_details')
+        end
+
+        def case_details
+          case_details = object.application&.dig('case_details')
+          case_details['offence_class'] = nil
+          case_details.except!('offences', 'codefendants')
+          case_details
+        end
+
+        def interests_of_justice
+          object.application&.dig('interests_of_justice')
+        end
+
+        def ioj_passport
+          object.application&.dig('ioj_passport')
         end
 
         def reference

--- a/app/api/datastore/helpers/formatters.rb
+++ b/app/api/datastore/helpers/formatters.rb
@@ -1,0 +1,11 @@
+module Datastore
+  module Helpers
+    module Formatters
+      extend Grape::API::Helpers
+
+      Grape::Entity.format_with :iso8601 do |date|
+        date&.iso8601
+      end
+    end
+  end
+end

--- a/app/api/datastore/maat/applications.rb
+++ b/app/api/datastore/maat/applications.rb
@@ -14,7 +14,7 @@ module Datastore
               **declared(params).symbolize_keys
             ).call
 
-            present :records, app, with: Datastore::Entities::Maat::Application
+            present app, with: Datastore::Entities::Maat::Application
           end
         end
       end


### PR DESCRIPTION
## Description of change
Modifies `/maat/applications/{USN}` endpoint to return additional fields required for maat integration following an agreed schema being committed to the schema repo - [Relevant pr](https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/10)

Also adds a formatter helper to format the submitted at date field to iso8601 format to pass validation checks. This makes use of the Grape:Entity [format_with method](https://github.com/ruby-grape/grape-entity#example)

## Link to relevant ticket

[CRIMRE-256](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-256)

## Notes for reviewer / how to test
Sets offence_class to nil, this will need to be amended when the offence_class field is available in this ticket [CRIMRE-250](https://dsdmoj.atlassian.net/browse/CRIMRE-250)

Had a discussion with Tim and thought it might be worth discussing whether the schema validation check should occur when an application is marked as ready rather than when it is being pulled by Maat as any potential issues could be sorted at that point. For now, this PR only validates against the schema in the spec test and this should be enough for crime core to make a start using. 
