### PR TITLE
CRIMAP-331 Task to add `means_passport` attribute

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,7 +1,7 @@
 class CrimeApplication < ApplicationRecord
   has_one :return_details, dependent: :destroy
 
-  attr_readonly :application, :submitted_at, :id
+  attr_readonly :submitted_at, :id
   enum status: Types::ApplicationStatus.mapping
   enum review_status: Types::ReviewApplicationStatus.mapping
 

--- a/lib/tasks/applications.rake
+++ b/lib/tasks/applications.rake
@@ -1,0 +1,15 @@
+namespace :applications do
+  # NOTE: this task can be deleted once it has been run
+  desc 'Add new means_passport attribute to existing applications'
+  task add_means_passport: :environment do
+    puts "Adding new `means_passport` attribute to existing applications"
+
+    means_attribute = { means_passport: ['on_benefit_check'] }.to_json
+
+    CrimeApplication.update_all(
+      "application = application || '#{means_attribute}'::jsonb"
+    )
+
+    puts "Done"
+  end
+end


### PR DESCRIPTION
## Description of change
Ancillary work required for means passporting refactor.

For context, PRs:
- https://github.com/ministryofjustice/laa-apply-for-criminal-legal-aid/pull/321
- https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/15

This task will add to all existing applications in the datastore, a new attribute `means_passport`.

Currently all submitted applications are passported `on_benefit_check`, can't be any other value, but soon new submitted applications might also be passported `on_age_under18` so better to run this task soon.

After the task has been run, this PR will be reverted.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-331

## Notes for reviewer / how to test
