### PR TITLE
Remove unused `ioj_passport` from MAAT json

### DIFF
--- a/app/api/datastore/entities/maat/application.rb
+++ b/app/api/datastore/entities/maat/application.rb
@@ -11,7 +11,6 @@ module Datastore
         expose :provider_details
         expose :case_details
         expose :interests_of_justice
-        expose :ioj_passport
 
         private
 
@@ -41,10 +40,6 @@ module Datastore
 
         def interests_of_justice
           application_value('interests_of_justice')
-        end
-
-        def ioj_passport
-          application_value('ioj_passport')
         end
 
         def reference

--- a/spec/api/datastore/maat/application_ready_spec.rb
+++ b/spec/api/datastore/maat/application_ready_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe 'get application ready for maat' do
           'provider_details' => application.application['provider_details'],
           'submitted_at' => application['submitted_at'].iso8601,
           'date_stamp' => application.application['date_stamp'],
-          'ioj_passport' => application.application['ioj_passport'],
           'interests_of_justice' => application.application['interests_of_justice'],
           'case_details' => expected_case_details,
           'schema_version' => 1.0,


### PR DESCRIPTION
## Description of change
This attribute holds the different IoJ passporting triggered on Apply, and is used on Review to present status badges.

However it is probably not needed for MAAT and we can remove it.

TODO: we may want to do a final audit of attributes once MAAT integration concludes.

