### PR TITLE
CRIMAP-328 Disable rails `force_ssl` setting

### DIFF
--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -8,3 +8,5 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
+  # Datastore is accessed via local cluster networking (no SSL)
+  DISABLE_HTTPS: enabled


### PR DESCRIPTION
## Description of change
We are evaluating internal cross-namespace networking between Apply/Review and Datastore.

Internal traffic doesn't use https but Rails by default force it on production environments.

If we decide to keep both, internal cluster connectivity, and external ingress, then we can force the redirect to https at the nginx/ingress level instead of Rails, so both can work (http for internal access and https for external access).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-328
