### PR TITLE
Add empty root path response

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   mount Datastore::Root => '/'
 
+  root to: proc { [200, {}, ['']] }
+
   get :ping, to: 'status#ping'
   get :health, to: 'status#health'
 

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Root' do
+  describe 'index' do
+    it 'has the expected response' do
+      get root_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This removes a 404 when accessing the datastore root path in production envs, which can be confusing or think the service is down.
