### PR TITLE
Update postgres ci-cd version following rds upgrade

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.6-alpine
+        image: postgres:15.2-alpine
         env:
           POSTGRES_DB: laa-criminal-applications-datastore-test
           POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ x-common-variables: &common-variables
 
 services:
   db:
-    image: postgres:14.6-alpine
+    image: postgres:15.2-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 


### PR DESCRIPTION
## Description of change
The version of postgres in cloud platform datastore staging namespace has been upgraded to 15.2.
For consistency, use the same version in the CI/CD pipeline and in the docker-compose file.

## Link to relevant ticket
[CRIMAP-343](https://dsdmoj.atlassian.net/jira/software/projects/CRIMAP/boards/897?selectedIssue=CRIMAP-343)

## Notes for reviewer / how to test


[CRIMAP-343]: https://dsdmoj.atlassian.net/browse/CRIMAP-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ