### PR TITLE
CRIMAP-349 Perform authorisation per endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 
 # Datastore API authentication
-gem 'moj-simple-jwt-auth', '0.0.1'
+gem 'moj-simple-jwt-auth', '0.1.0'
 
 # SNS messaging
 gem 'aws-sdk-sns'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.18.0)
-    moj-simple-jwt-auth (0.0.1)
+    moj-simple-jwt-auth (0.1.0)
       json
       jwt
     multi_json (1.15.0)
@@ -321,7 +321,7 @@ DEPENDENCIES
   grape_logging
   kaminari-activerecord
   laa-criminal-legal-aid-schemas!
-  moj-simple-jwt-auth (= 0.0.1)
+  moj-simple-jwt-auth (= 0.1.0)
   pg (~> 1.4)
   pry
   puma

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -5,10 +5,17 @@ module Datastore
 
     # JWT auth middleware from `moj-simple-jwt-auth` gem
     auth :jwt
+    use SimpleJwtAuth::Middleware::Grape::Authorisation
 
     mount V2::Applications
     mount V2::Searches
     mount V2::Reviewing
     mount Maat::Applications
+
+    desc 'Catch-all route'
+    route_setting :authorised_consumers, %w[*]
+    route :any, '*path' do
+      error!({ status: 404, error: 'Not found' }, 404)
+    end
   end
 end

--- a/app/api/datastore/v2/applications.rb
+++ b/app/api/datastore/v2/applications.rb
@@ -5,6 +5,7 @@ module Datastore
 
       resource :applications do
         desc 'Create an application.'
+        route_setting :authorised_consumers, %w[crime-apply]
         params do
           requires :application, type: JSON, desc: 'Application JSON payload.'
         end
@@ -15,6 +16,7 @@ module Datastore
         end
 
         desc 'Return an application by ID.'
+        route_setting :authorised_consumers, %w[crime-apply crime-review]
         params do
           requires :id, type: String, desc: 'Application UUID.'
         end
@@ -25,6 +27,7 @@ module Datastore
         end
 
         desc 'Return applications with pagination.'
+        route_setting :authorised_consumers, %w[crime-apply]
         params do
           use :sorting
           use :pagination

--- a/app/api/datastore/v2/reviewing.rb
+++ b/app/api/datastore/v2/reviewing.rb
@@ -3,6 +3,8 @@ module Datastore
     class Reviewing < Base
       version 'v2', using: :path
 
+      route_setting :authorised_consumers, %w[crime-review]
+
       resource :applications do
         desc 'Return an application to provider.'
         params do

--- a/app/api/datastore/v2/searches.rb
+++ b/app/api/datastore/v2/searches.rb
@@ -4,6 +4,8 @@ module Datastore
     class Searches < Base
       version 'v2', using: :path
 
+      route_setting :authorised_consumers, %w[crime-review]
+
       resource :searches do
         desc 'Search the Datastore.'
         params do

--- a/spec/api/datastore/root_spec.rb
+++ b/spec/api/datastore/root_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Root' do
+  describe 'handle unknown routes' do
+    subject(:api_request) { get '/api/v1/foobar' }
+
+    before do
+      api_request
+    end
+
+    it_behaves_like 'an authorisable endpoint', %w[*]
+
+    it 'returns http status 404' do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns the error details' do
+      expect(
+        JSON.parse(response.body)
+      ).to eq({ 'error' => 'Not found', 'status' => 404 })
+    end
+  end
+end

--- a/spec/api/datastore/v2/create_application_spec.rb
+++ b/spec/api/datastore/v2/create_application_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'create application' do
 
     let(:submission_event) { instance_double(Events::Submission, publish: true) }
 
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply] do
+      before { api_request }
+    end
+
     context 'with a valid request' do
       before do
         allow(CrimeApplication).to receive(:create!).with(

--- a/spec/api/datastore/v2/get_application_spec.rb
+++ b/spec/api/datastore/v2/get_application_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'get application' do
       get "/api/v2/applications/#{application_id}"
     end
 
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply crime-review] do
+      before { api_request }
+    end
+
     context 'when found' do
       before do
         allow(CrimeApplication).to receive(:find)

--- a/spec/api/datastore/v2/list_applications_spec.rb
+++ b/spec/api/datastore/v2/list_applications_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe 'list applications' do
     get "/api/v2/applications#{query}"
   end
 
+  let(:query) { nil }
   let(:records_count) { JSON.parse(response.body).fetch('records').count }
+
+  it_behaves_like 'an authorisable endpoint', %w[crime-apply] do
+    before { api_request }
+  end
 
   describe 'pagination' do
     subject(:pagination) do
@@ -21,8 +26,6 @@ RSpec.describe 'list applications' do
     end
 
     context 'without page param' do
-      let(:query) { nil }
-
       it 'returns the first page of results with pagination headers' do
         expect(pagination['current_page']).to eq 1
         expect(pagination['total_count']).to eq 21

--- a/spec/api/datastore/v2/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/complete_application_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'complete application' do
       )
     end
 
+    it_behaves_like 'an authorisable endpoint', %w[crime-review] do
+      before { api_request }
+    end
+
     context 'with a submitted application' do
       it 'marks the application as complete' do
         expect { api_request }.to change { application.reload.review_status }

--- a/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/mark_as_ready_application_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe 'ready for assessment application' do
       )
     end
 
+    it_behaves_like 'an authorisable endpoint', %w[crime-review] do
+      before { api_request }
+    end
+
     context 'with a submitted application' do
       it 'marks the application as ready for assessment' do
         expect { api_request }.to change { application.reload.review_status }

--- a/spec/api/datastore/v2/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v2/reviewing/return_application_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'return application' do
       )
     end
 
+    it_behaves_like 'an authorisable endpoint', %w[crime-review] do
+      before { api_request }
+    end
+
     context 'with a submitted application' do
       it 'marks the application as returned' do
         expect { api_request }.to change { application.reload.status }

--- a/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v2/searches/search_by_name_and_reference_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'search with text' do
     api_request
   end
 
+  it_behaves_like 'an authorisable endpoint', %w[crime-review]
+
   it 'defaults to showing all applications' do
     expect(records.count).to be 3
     expect(records.pluck('resource_id')).to match_array(CrimeApplication.pluck(:id))

--- a/spec/support/shared_examples/routing_shared_examples.rb
+++ b/spec/support/shared_examples/routing_shared_examples.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'an authorisable endpoint' do |consumers|
+  let(:authorised_consumers) do
+    request.env['grape.routing_args'][:route_info].settings[:authorised_consumers]
+  end
+
+  it 'declares authorised consumers' do
+    expect(authorised_consumers).to match_array(consumers)
+  end
+end


### PR DESCRIPTION
## Description of change
The datastore currently implements authentication via JWT tokens but it doesn’t perform “authorisation“ to limit access of consumers to endpoints that are out of their business.

For instance, we would want MAAT adapter consumer to only have access to the endpoint(s) relevant to them, and to not have access to the create application endpoint, or the search applications endpoint.

In order to do that we have to “annotate“ each endpoint to declare which consumers (JWT issuer) are allowed to call those endpoints. If they are not allowed, return forbidden.

This is making use of the new Grape middleware implemented in the `SimpleJwtAuth` gem that handles this authorisation based on the annotation as a before filter.

NOTE: maat endpoint not yet annotated as it needs a refactor first and agreeing with them the issuer name.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-349

## Notes for reviewer / how to test
