### PR TITLE
Implement API-scoped health check

### DIFF
--- a/app/api/datastore/entities/healthcheck.rb
+++ b/app/api/datastore/entities/healthcheck.rb
@@ -1,0 +1,8 @@
+module Datastore
+  module Entities
+    class Healthcheck < Grape::Entity
+      expose :status
+      expose :error
+    end
+  end
+end

--- a/app/api/datastore/root.rb
+++ b/app/api/datastore/root.rb
@@ -10,6 +10,7 @@ module Datastore
     mount V2::Applications
     mount V2::Searches
     mount V2::Reviewing
+    mount V2::Healthcheck
     mount Maat::Applications
 
     desc 'Catch-all route'

--- a/app/api/datastore/v2/healthcheck.rb
+++ b/app/api/datastore/v2/healthcheck.rb
@@ -1,0 +1,18 @@
+module Datastore
+  module V2
+    class Healthcheck < Base
+      version 'v2', using: :path
+
+      resource :health do
+        desc 'Performs a basic health check'
+        route_setting :authorised_consumers, %w[*]
+        get do
+          result = Status::Healthcheck.call
+
+          status  result.status
+          present result, with: Datastore::Entities::Healthcheck
+        end
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v2/healthcheck_spec.rb
+++ b/spec/api/datastore/v2/healthcheck_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Healthcheck' do
+  describe 'GET /health' do
+    subject(:api_request) { get '/api/v2/health' }
+
+    it_behaves_like 'an authorisable endpoint', %w[*] do
+      before { api_request }
+    end
+
+    context 'when service is healthy' do
+      before do
+        api_request
+      end
+
+      it 'returns status ok' do
+        expect(response).to have_http_status(:ok)
+
+        expect(
+          response.parsed_body
+        ).to eq('status' => 'ok', 'error' => nil)
+      end
+    end
+
+    context 'when service is unhealthy' do
+      before do
+        allow(ActiveRecord::Base).to receive(:connection) {
+          raise StandardError
+        }
+
+        api_request
+      end
+
+      it 'returns service unavailable' do
+        expect(response).to have_http_status(:service_unavailable)
+
+        expect(
+          response.parsed_body
+        ).to eq('status' => 'service_unavailable', 'error' => 'Database Connection Error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
This endpoint uses the same existing `Status::Healthcheck` service object but exposes it through the API at the endpoint `/api/v2/health`, performing authentication via JWT but allowing any consumers to call it.

This allows for consumers to implement their own probes and also to test their JWT implementations easily, without us having to provide to them existing application UUIDs or USNs. Thinking of MAAT adapter mainly.

## Link to relevant ticket

## Notes for reviewer / how to test
