### PR TITLE
Onboard MAAT adapter consumer

### DIFF
--- a/app/api/datastore/maat/applications.rb
+++ b/app/api/datastore/maat/applications.rb
@@ -3,6 +3,8 @@ module Datastore
     class Applications < Base
       version 'maat', using: :path
 
+      route_setting :authorised_consumers, %w[maat-adapter]
+
       resource :applications do
         desc 'Return an application by USN.'
         params do

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -10,5 +10,6 @@ SimpleJwtAuth.configure do |config|
   config.secrets_config = {
     'crime-apply' => ENV.fetch('API_AUTH_SECRET_APPLY', nil),
     'crime-review' => ENV.fetch('API_AUTH_SECRET_REVIEW', nil),
+    'maat-adapter' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER', nil),
   }
 end

--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -67,16 +67,21 @@ spec:
               secretKeyRef:
                 name: rds-instance
                 key: url
-#          - name: API_AUTH_SECRET_APPLY
-#            valueFrom:
-#              secretKeyRef:
-#                name: api-auth-secrets
-#                key: crime_apply
-#          - name: API_AUTH_SECRET_REVIEW
-#            valueFrom:
-#              secretKeyRef:
-#                name: api-auth-secrets
-#                key: crime_review
+          - name: API_AUTH_SECRET_APPLY
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: crime_apply
+          - name: API_AUTH_SECRET_REVIEW
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: crime_review
+          - name: API_AUTH_SECRET_MAAT_ADAPTER
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: maat_adapter
           - name: EVENTS_SNS_TOPIC_ARN
             valueFrom:
               secretKeyRef:

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -77,6 +77,11 @@ spec:
               secretKeyRef:
                 name: api-auth-secrets
                 key: crime_review
+          - name: API_AUTH_SECRET_MAAT_ADAPTER
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: maat_adapter
           - name: EVENTS_SNS_TOPIC_ARN
             valueFrom:
               secretKeyRef:

--- a/spec/api/datastore/maat/application_ready_spec.rb
+++ b/spec/api/datastore/maat/application_ready_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe 'get application ready for maat' do
     let(:application_usn) { application.application['reference'] }
     let(:maat_application) { JSON.parse(response.body) }
 
+    it_behaves_like 'an authorisable endpoint', %w[maat-adapter] do
+      before { api_request }
+    end
+
     context 'with a ready for assessment application' do
       before do
         api_request


### PR DESCRIPTION
## Description of change
Configure SimpleJwtAuth with the consumer shared secret (created by terraform) for MAAT adapter.

Permit their endpoint.

## Link to relevant ticket

## Notes for reviewer / how to test
