### PR TITLE
Change the way SimpleJwtAuth sets the logger

### DIFF
--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -1,15 +1,20 @@
 require 'simple_jwt_auth'
 
-SimpleJwtAuth.configure do |config|
-  # Log level inherited from Rails logger, by default
-  # `debug` in development/test and `info` in production
-  config.logger = Rails.logger
+Rails.application.config.to_prepare do
+  SimpleJwtAuth.configure do |config|
+    # Use same logger from Grape API
+    config.logger = Datastore::Base.logger
 
-  # A map of consumers of the API and their secrets
-  # On kubernetes, secrets are created by terraform
-  config.secrets_config = {
-    'crime-apply' => ENV.fetch('API_AUTH_SECRET_APPLY', nil),
-    'crime-review' => ENV.fetch('API_AUTH_SECRET_REVIEW', nil),
-    'maat-adapter' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER', nil),
-  }
+    # Log level inherited from Rails logger, by default
+    # `debug` in development/test and `info` in production
+    config.logger.level = Rails.logger.level
+
+    # A map of consumers of the API and their secrets
+    # On kubernetes, secrets are created by terraform
+    config.secrets_config = {
+      'crime-apply' => ENV.fetch('API_AUTH_SECRET_APPLY', nil),
+      'crime-review' => ENV.fetch('API_AUTH_SECRET_REVIEW', nil),
+      'maat-adapter' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER', nil),
+    }
+  end
 end


### PR DESCRIPTION
## Description of change
Instead of `Rails.logger`, use the logger provided by Grape, which will allow us to output to stdout any logging produced by SimpleJwtAuth (in production that will be warns and errors).

The level is still set from Rails logger (different in dev/test and in production).

Wrap the configuration block in a Rails `to_prepare` so the logger is already initialised by the time we are assigning it.
