### PR TITLE
Allow apply to call the return application endpoint

### DIFF
--- a/app/api/datastore/v1/reviewing.rb
+++ b/app/api/datastore/v1/reviewing.rb
@@ -3,8 +3,6 @@ module Datastore
     class Reviewing < Base
       version 'v1', using: :path
 
-      route_setting :authorised_consumers, %w[crime-review]
-
       resource :applications do
         desc 'Return an application to provider.'
         params do
@@ -17,6 +15,7 @@ module Datastore
 
         route_param :application_id do
           resource :return do
+            route_setting :authorised_consumers, %w[crime-apply crime-review]
             put do
               return_params = declared(params).symbolize_keys
               app = Operations::ReturnApplication.new(**return_params).call
@@ -32,6 +31,7 @@ module Datastore
 
         route_param :application_id do
           resource :complete do
+            route_setting :authorised_consumers, %w[crime-review]
             put do
               Datastore::Entities::V1::CrimeApplication.represent(
                 Operations::CompleteApplication.new(application_id: params[:application_id]).call
@@ -47,6 +47,7 @@ module Datastore
 
         route_param :application_id do
           resource :mark_as_ready do
+            route_setting :authorised_consumers, %w[crime-review]
             put do
               Datastore::Entities::V1::CrimeApplication.represent(
                 Operations::MarkAsReadyApplication.new(application_id: params[:application_id]).call

--- a/spec/api/datastore/v1/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/return_application_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'return application' do
       )
     end
 
-    it_behaves_like 'an authorisable endpoint', %w[crime-review] do
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply crime-review] do
       before { api_request }
     end
 


### PR DESCRIPTION
## Description of change
In locking down the different endpoints, I forgot Apply make use of the return endpoint in the developer tools (non-prod) as a quick way to mark an application as returned without having to run Review locally.

This is of great help during development of the IoJ/Means passporting and edge cases as allow for a very quick feedback loop (everything can be done from Apply without Review involvement). Also helpful for quick tests on staging.

For the time being until we don't need this anymore, enable this endpoint again to be called by Apply. Before release, we can turn this off again, or allow it only on non-prod envs (localhost/staging).

## Link to relevant ticket

## Notes for reviewer / how to test
