### PR TITLE
Persist overall offence class to datastore at point of submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.5'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.6'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 7df6ac728db24326bf32b55afb99c8607296ef85
+  revision: 5f18ff9ac519360826fda2f5373ffb8da2d8336c
   tag: v0.1.6
   specs:
     laa-criminal-legal-aid-schemas (0.1.6)
@@ -306,7 +306,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 933253dc37dc20c51efe962418c59f4d8bf8c75b
-  tag: v0.1.5
+  revision: 7df6ac728db24326bf32b55afb99c8607296ef85
+  tag: v0.1.6
   specs:
-    laa-criminal-legal-aid-schemas (0.1.4)
+    laa-criminal-legal-aid-schemas (0.1.6)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/app/api/datastore/entities/v1/crime_application.rb
+++ b/app/api/datastore/entities/v1/crime_application.rb
@@ -70,7 +70,7 @@ module Datastore
         end
 
         def submitted_value(name)
-          object.submitted_details&.dig(name)
+          object.submitted_application&.dig(name)
         end
       end
     end

--- a/app/api/datastore/entities/v1/crime_application.rb
+++ b/app/api/datastore/entities/v1/crime_application.rb
@@ -2,10 +2,76 @@ module Datastore
   module Entities
     module V1
       class CrimeApplication < Grape::Entity
-        expose :application, merge: true
+        expose :id
+        expose :schema_version
+        expose :reference
+        expose :created_at
+        expose :submitted_at, format_with: :iso8601
+        expose :returned_at, expose_nil: false
+        expose :date_stamp
+        expose :provider_details
+        expose :client_details
+        expose :case_details
+        expose :interests_of_justice
+        expose :ioj_passport
+        expose :means_passport
 
         expose :status
         expose :return_details, using: V1::ReturnDetails, expose_nil: false
+
+        private
+
+        def id
+          submitted_value('id')
+        end
+
+        def schema_version
+          submitted_value('schema_version')
+        end
+
+        def client_details
+          submitted_value('client_details')
+        end
+
+        # created_at is the date when the application was started on crime apply
+        # and therefore we take the value from the application json rather than the table
+        def created_at
+          submitted_value('created_at')
+        end
+
+        def date_stamp
+          submitted_value('date_stamp')
+        end
+
+        def provider_details
+          submitted_value('provider_details')
+        end
+
+        def case_details
+          case_details = submitted_value('case_details') || {}
+          case_details['offence_class'] = object.offence_class
+          case_details
+        end
+
+        def interests_of_justice
+          submitted_value('interests_of_justice')
+        end
+
+        def reference
+          submitted_value('reference').to_i
+        end
+
+        def ioj_passport
+          submitted_value('ioj_passport')
+        end
+
+        def means_passport
+          submitted_value('means_passport')
+        end
+
+        def submitted_value(name)
+          object.submitted_details&.dig(name)
+        end
       end
     end
   end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -16,7 +16,7 @@ module Datastore
           private
 
           def client_details
-            application_value('client_details')
+            submitted_value('client_details')
           end
 
           def schema_version
@@ -24,31 +24,30 @@ module Datastore
           end
 
           def date_stamp
-            application_value('date_stamp')
+            submitted_value('date_stamp')
           end
 
           def provider_details
-            application_value('provider_details')
+            submitted_value('provider_details')
           end
 
           def case_details
-            case_details = application_value('case_details')
-            case_details['offence_class'] =
-              Utils::OffenceClassCalculator.new(offences: case_details['offences']).offence_class
+            case_details = submitted_value('case_details')
+            case_details['offence_class'] = object.offence_class
             case_details.except!('offences', 'codefendants')
             case_details
           end
 
           def interests_of_justice
-            application_value('interests_of_justice')
+            submitted_value('interests_of_justice')
           end
 
           def reference
-            application_value('reference').to_i
+            submitted_value('reference').to_i
           end
 
-          def application_value(name)
-            object.application&.dig(name)
+          def submitted_value(name)
+            object.submitted_details&.dig(name)
           end
         end
       end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -47,7 +47,7 @@ module Datastore
           end
 
           def submitted_value(name)
-            object.submitted_details&.dig(name)
+            object.submitted_application&.dig(name)
           end
         end
       end

--- a/app/api/datastore/entities/v1/search_result.rb
+++ b/app/api/datastore/entities/v1/search_result.rb
@@ -18,15 +18,15 @@ module Datastore
         end
 
         def applicant
-          object.application&.dig('client_details', 'applicant')
+          object.submitted_details&.dig('client_details', 'applicant')
         end
 
         def parent_id
-          object.application&.dig('parent_id')
+          object.submitted_details&.dig('parent_id')
         end
 
         def reference
-          object.application&.dig('reference').to_i
+          object.submitted_details&.dig('reference').to_i
         end
       end
     end

--- a/app/api/datastore/entities/v1/search_result.rb
+++ b/app/api/datastore/entities/v1/search_result.rb
@@ -18,15 +18,15 @@ module Datastore
         end
 
         def applicant
-          object.submitted_details&.dig('client_details', 'applicant')
+          object.submitted_application&.dig('client_details', 'applicant')
         end
 
         def parent_id
-          object.submitted_details&.dig('parent_id')
+          object.submitted_application&.dig('parent_id')
         end
 
         def reference
-          object.submitted_details&.dig('reference').to_i
+          object.submitted_application&.dig('reference').to_i
         end
       end
     end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -24,11 +24,10 @@ class CrimeApplication < ApplicationRecord
   end
 
   def set_overall_offence_class
-    return unless id.nil?
     return unless submitted_details
 
-    Rails.logger.debug submitted_details
-    offences = submitted_details['case_details']['offences']
-    self.offence_class = Utils::OffenceClassCalculator.new(offences:).offence_class
+    self.offence_class = Utils::OffenceClassCalculator.new(
+      offences: submitted_details['case_details']['offences']
+    ).offence_class
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,7 +1,7 @@
 class CrimeApplication < ApplicationRecord
   has_one :return_details, dependent: :destroy
 
-  attr_readonly :submitted_details, :submitted_at, :id
+  attr_readonly :submitted_application, :submitted_at, :id
   enum status: Types::ApplicationStatus.mapping
   enum review_status: Types::ReviewApplicationStatus.mapping
 
@@ -10,24 +10,24 @@ class CrimeApplication < ApplicationRecord
 
   scope :by_status, ->(status) { where(status:) }
   scope :by_office, lambda { |office_code|
-    where("submitted_details->'provider_details'->>'office_code' = ?", office_code)
+    where("submitted_application->'provider_details'->>'office_code' = ?", office_code)
   }
 
   private
 
   def shift_payload_attributes
     return unless id.nil?
-    return unless submitted_details
+    return unless submitted_application
 
-    self.id = submitted_details.fetch('id')
-    self.submitted_at = submitted_details.fetch('submitted_at')
+    self.id = submitted_application.fetch('id')
+    self.submitted_at = submitted_application.fetch('submitted_at')
   end
 
   def set_overall_offence_class
-    return unless submitted_details
+    return unless submitted_application
 
     self.offence_class = Utils::OffenceClassCalculator.new(
-      offences: submitted_details['case_details']['offences']
+      offences: submitted_application['case_details']['offences']
     ).offence_class
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,24 +1,34 @@
 class CrimeApplication < ApplicationRecord
   has_one :return_details, dependent: :destroy
 
-  attr_readonly :application, :submitted_at, :id
+  attr_readonly :submitted_details, :submitted_at, :id
   enum status: Types::ApplicationStatus.mapping
   enum review_status: Types::ReviewApplicationStatus.mapping
 
   before_validation :shift_payload_attributes, on: :create
+  before_validation :set_overall_offence_class, on: :create
 
   scope :by_status, ->(status) { where(status:) }
   scope :by_office, lambda { |office_code|
-    where("application->'provider_details'->>'office_code' = ?", office_code)
+    where("submitted_details->'provider_details'->>'office_code' = ?", office_code)
   }
 
   private
 
   def shift_payload_attributes
     return unless id.nil?
-    return unless application
+    return unless submitted_details
 
-    self.id = application.fetch('id')
-    self.submitted_at = application.fetch('submitted_at')
+    self.id = submitted_details.fetch('id')
+    self.submitted_at = submitted_details.fetch('submitted_at')
+  end
+
+  def set_overall_offence_class
+    return unless id.nil?
+    return unless submitted_details
+
+    Rails.logger.debug submitted_details
+    offences = submitted_details['case_details']['offences']
+    self.offence_class = Utils::OffenceClassCalculator.new(offences:).offence_class
   end
 end

--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -27,7 +27,7 @@ class SearchFilter
 
   def filter_applicant_date_of_birth(scope)
     scope.where(
-      "application->'client_details'->'applicant'->>'date_of_birth' = ?::text",
+      "submitted_details->'client_details'->'applicant'->>'date_of_birth' = ?::text",
       applicant_date_of_birth
     )
   end

--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -27,7 +27,7 @@ class SearchFilter
 
   def filter_applicant_date_of_birth(scope)
     scope.where(
-      "submitted_details->'client_details'->'applicant'->>'date_of_birth' = ?::text",
+      "submitted_application->'client_details'->'applicant'->>'date_of_birth' = ?::text",
       applicant_date_of_birth
     )
   end

--- a/app/services/events/submission.rb
+++ b/app/services/events/submission.rb
@@ -8,7 +8,7 @@ module Events
       {
         id: crime_application.id,
         submitted_at: crime_application.submitted_at,
-        parent_id: crime_application.submitted_details['parent_id']
+        parent_id: crime_application.submitted_application['parent_id']
       }
     end
   end

--- a/app/services/events/submission.rb
+++ b/app/services/events/submission.rb
@@ -8,7 +8,7 @@ module Events
       {
         id: crime_application.id,
         submitted_at: crime_application.submitted_at,
-        parent_id: crime_application.application['parent_id']
+        parent_id: crime_application.submitted_details['parent_id']
       }
     end
   end

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -12,7 +12,7 @@ module Operations
 
     def call
       CrimeApplication.transaction do
-        @app = CrimeApplication.create!(application: payload)
+        @app = CrimeApplication.create!(submitted_details: payload)
         SupersedeApplication.new(application_id: parent_id).call if parent_id
 
         # Publish event notification to the SNS topic

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -12,7 +12,7 @@ module Operations
 
     def call
       CrimeApplication.transaction do
-        @app = CrimeApplication.create!(submitted_details: payload)
+        @app = CrimeApplication.create!(submitted_application: payload)
         SupersedeApplication.new(application_id: parent_id).call if parent_id
 
         # Publish event notification to the SNS topic

--- a/app/services/utils/offence_class_calculator.rb
+++ b/app/services/utils/offence_class_calculator.rb
@@ -2,8 +2,6 @@ module Utils
   class OffenceClassCalculator
     attr_reader :offences
 
-    OFFENCE_CLASS_RANKING = %w[a k g b i j d c h f e].freeze
-
     def initialize(offences:)
       @offences = offences
     end
@@ -24,7 +22,7 @@ module Utils
 
     def rank_offences
       offences_classes = offences.pluck(:offence_class)
-      offences_classes.sort_by { |oc| OFFENCE_CLASS_RANKING.index oc.downcase }
+      offences_classes.sort_by { |oc| Types::OffenceClass.values.index oc }
     end
 
     def any_manually_entered_offences?

--- a/db/migrate/20230509112219_add_offence_class_to_crime_applications.rb
+++ b/db/migrate/20230509112219_add_offence_class_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddOffenceClassToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:crime_applications, :offence_class, :string)
+  end
+end

--- a/db/migrate/20230510093121_rename_application_to_submitted_details.rb
+++ b/db/migrate/20230510093121_rename_application_to_submitted_details.rb
@@ -1,7 +1,0 @@
-class RenameApplicationToSubmittedDetails < ActiveRecord::Migration[7.0]
-  def change
-    change_table :crime_applications do |t|
-      t.rename :application, :submitted_details
-    end
-  end
-end

--- a/db/migrate/20230510093121_rename_application_to_submitted_details.rb
+++ b/db/migrate/20230510093121_rename_application_to_submitted_details.rb
@@ -1,0 +1,7 @@
+class RenameApplicationToSubmittedDetails < ActiveRecord::Migration[7.0]
+  def change
+    change_table :crime_applications do |t|
+      t.rename :application, :submitted_details
+    end
+  end
+end

--- a/db/migrate/20230511102128_rename_application_to_submitted_application.rb
+++ b/db/migrate/20230511102128_rename_application_to_submitted_application.rb
@@ -1,0 +1,7 @@
+class RenameApplicationToSubmittedApplication < ActiveRecord::Migration[7.0]
+  def change
+    change_table :crime_applications do |t|
+      t.rename :application, :submitted_application
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_093121) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "submitted_details"
+    t.jsonb "submitted_application"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status", default: "submitted", null: false
     t.datetime "submitted_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "returned_at", precision: nil
-    t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (submitted_details #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (submitted_details #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (submitted_details ->> 'reference'::text)))", stored: true
+    t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (submitted_application #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (submitted_application #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (submitted_application ->> 'reference'::text)))", stored: true
     t.datetime "reviewed_at", precision: nil
     t.string "review_status", default: "application_received", null: false
-    t.virtual "reference", type: :integer, as: "((submitted_details ->> 'reference'::text))::integer", stored: true
-    t.virtual "applicant_first_name", type: :citext, as: "(submitted_details #>> '{client_details,applicant,first_name}'::text[])", stored: true
-    t.virtual "applicant_last_name", type: :citext, as: "(submitted_details #>> '{client_details,applicant,last_name}'::text[])", stored: true
+    t.virtual "reference", type: :integer, as: "((submitted_application ->> 'reference'::text))::integer", stored: true
+    t.virtual "applicant_first_name", type: :citext, as: "(submitted_application #>> '{client_details,applicant,first_name}'::text[])", stored: true
+    t.virtual "applicant_last_name", type: :citext, as: "(submitted_application #>> '{client_details,applicant,last_name}'::text[])", stored: true
     t.string "offence_class"
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_21_154839) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_093121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.jsonb "application"
+    t.jsonb "submitted_details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status", default: "submitted", null: false
     t.datetime "submitted_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "returned_at", precision: nil
-    t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (application #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (application ->> 'reference'::text)))", stored: true
+    t.virtual "searchable_text", type: :tsvector, as: "((to_tsvector('english'::regconfig, (submitted_details #>> '{client_details,applicant,first_name}'::text[])) || to_tsvector('english'::regconfig, (submitted_details #>> '{client_details,applicant,last_name}'::text[]))) || to_tsvector('english'::regconfig, (submitted_details ->> 'reference'::text)))", stored: true
     t.datetime "reviewed_at", precision: nil
     t.string "review_status", default: "application_received", null: false
-    t.virtual "reference", type: :integer, as: "((application ->> 'reference'::text))::integer", stored: true
-    t.virtual "applicant_first_name", type: :citext, as: "(application #>> '{client_details,applicant,first_name}'::text[])", stored: true
-    t.virtual "applicant_last_name", type: :citext, as: "(application #>> '{client_details,applicant,last_name}'::text[])", stored: true
+    t.virtual "reference", type: :integer, as: "((submitted_details ->> 'reference'::text))::integer", stored: true
+    t.virtual "applicant_first_name", type: :citext, as: "(submitted_details #>> '{client_details,applicant,first_name}'::text[])", stored: true
+    t.virtual "applicant_last_name", type: :citext, as: "(submitted_details #>> '{client_details,applicant,last_name}'::text[])", stored: true
+    t.string "offence_class"
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
       returned_at:,
       return_details:,
       offence_class:,
-      submitted_details:
+      submitted_application:
     )
   end
 
@@ -34,37 +34,37 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
     }
   end
 
-  let(:submitted_details) do
+  let(:submitted_application) do
     JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
   end
 
   context 'when retrieved from the submitted details' do
     it 'represents the provider details' do
-      expect(representation.fetch('provider_details')).to eq submitted_details.fetch('provider_details')
+      expect(representation.fetch('provider_details')).to eq submitted_application.fetch('provider_details')
     end
 
     it 'represents the client details' do
-      expect(representation.fetch('client_details')).to eq submitted_details.fetch('client_details')
+      expect(representation.fetch('client_details')).to eq submitted_application.fetch('client_details')
     end
 
     it 'represents the interests of justice details' do
-      expect(representation.fetch('interests_of_justice')).to eq submitted_details.fetch('interests_of_justice')
+      expect(representation.fetch('interests_of_justice')).to eq submitted_application.fetch('interests_of_justice')
     end
 
     it 'represents the interests of justice passport details' do
-      expect(representation.fetch('ioj_passport')).to eq submitted_details.fetch('ioj_passport')
+      expect(representation.fetch('ioj_passport')).to eq submitted_application.fetch('ioj_passport')
     end
 
     it 'represents the means passport details' do
-      expect(representation.fetch('means_passport')).to eq submitted_details.fetch('means_passport')
+      expect(representation.fetch('means_passport')).to eq submitted_application.fetch('means_passport')
     end
 
     it 'represents the reference' do
-      expect(representation.fetch('reference')).to eq submitted_details.fetch('reference')
+      expect(representation.fetch('reference')).to eq submitted_application.fetch('reference')
     end
 
     it 'represents the id' do
-      expect(representation.fetch('id')).to eq submitted_details.fetch('id')
+      expect(representation.fetch('id')).to eq submitted_application.fetch('id')
     end
   end
 

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::Entities::V1::CrimeApplication do
+  subject(:representation) do
+    JSON.parse(described_class.represent(crime_application).to_json)
+  end
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      id:,
+      status:,
+      submitted_at:,
+      reviewed_at:,
+      returned_at:,
+      return_details:,
+      offence_class:,
+      submitted_details:
+    )
+  end
+
+  let(:id) { SecureRandom.uuid }
+  let(:submitted_at) { 3.days.ago }
+  let(:reviewed_at) { nil }
+  let(:status) { Types::ApplicationStatus['submitted'] }
+  let(:offence_class) { Types::OffenceClass['C'] }
+  let(:case_details) { { offence_class: } }
+  let(:returned_at) { 3.days.ago }
+  let(:return_details) do
+    {
+      reason: nil,
+      details: nil,
+      returned_at: nil
+    }
+  end
+
+  let(:submitted_details) do
+    JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+  end
+
+  context 'when retrieved from the submitted details' do
+    it 'represents the provider details' do
+      expect(representation.fetch('provider_details')).to eq submitted_details.fetch('provider_details')
+    end
+
+    it 'represents the client details' do
+      expect(representation.fetch('client_details')).to eq submitted_details.fetch('client_details')
+    end
+
+    it 'represents the interests of justice details' do
+      expect(representation.fetch('interests_of_justice')).to eq submitted_details.fetch('interests_of_justice')
+    end
+
+    it 'represents the interests of justice passport details' do
+      expect(representation.fetch('ioj_passport')).to eq submitted_details.fetch('ioj_passport')
+    end
+
+    it 'represents the means passport details' do
+      expect(representation.fetch('means_passport')).to eq submitted_details.fetch('means_passport')
+    end
+
+    it 'represents the reference' do
+      expect(representation.fetch('reference')).to eq submitted_details.fetch('reference')
+    end
+
+    it 'represents the id' do
+      expect(representation.fetch('id')).to eq submitted_details.fetch('id')
+    end
+  end
+
+  context 'when retrieved from the database' do
+    it 'represents submitted_at in is8601' do
+      expect(representation.fetch('submitted_at')).to eq submitted_at.iso8601
+    end
+
+    it 'represents reviewed_at in is8601' do
+      expect(representation).not_to have_key(:reviewed_at)
+    end
+
+    it 'represents the status' do
+      expect(representation.fetch('status')).to eq status
+    end
+
+    it 'represents the return_details' do
+      expect(representation.fetch('return_details').symbolize_keys).to eq return_details
+    end
+  end
+
+  it 'represents the overall offence class within the case details' do
+    expect(representation.fetch('case_details').fetch('offence_class')).to eq offence_class
+  end
+end

--- a/spec/api/datastore/entities/v1/search_result_spec.rb
+++ b/spec/api/datastore/entities/v1/search_result_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   end
 
   let(:crime_application) do
-    instance_double(CrimeApplication, id:, review_status:, status:, submitted_at:, reviewed_at:, application:)
+    instance_double(CrimeApplication, id:, review_status:, status:, submitted_at:, reviewed_at:, submitted_details:)
   end
 
   let(:id) { SecureRandom.uuid }
@@ -16,7 +16,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   let(:status) { 'submitted' }
   let(:review_status) { 'assessment_completed' }
 
-  let(:application) do
+  let(:submitted_details) do
     JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_invalid').read).merge('parent_id' => parent_id)
   end
 

--- a/spec/api/datastore/entities/v1/search_result_spec.rb
+++ b/spec/api/datastore/entities/v1/search_result_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   end
 
   let(:crime_application) do
-    instance_double(CrimeApplication, id:, review_status:, status:, submitted_at:, reviewed_at:, submitted_details:)
+    instance_double(CrimeApplication, id:, review_status:, status:, submitted_at:, reviewed_at:, submitted_application:)
   end
 
   let(:id) { SecureRandom.uuid }
@@ -16,7 +16,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   let(:status) { 'submitted' }
   let(:review_status) { 'assessment_completed' }
 
-  let(:submitted_details) do
+  let(:submitted_application) do
     JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_invalid').read).merge('parent_id' => parent_id)
   end
 

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'create application' do
-  let(:application_id) { application.application['id'] }
+  let(:application_id) { application.submitted_details['id'] }
 
   let(:application) do
     instance_double(
       CrimeApplication,
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'create application' do
     context 'with a valid request' do
       before do
         allow(CrimeApplication).to receive(:create!).with(
-          application: JSON.parse(payload)
+          submitted_details: JSON.parse(payload)
         ).and_return(record)
 
         allow(
@@ -43,7 +43,7 @@ RSpec.describe 'create application' do
 
       it 'stores the application in the datastore' do
         expect(CrimeApplication).to have_received(:create!).with(
-          application: JSON.parse(payload)
+          submitted_details: JSON.parse(payload)
         )
       end
 
@@ -85,7 +85,7 @@ RSpec.describe 'create application' do
     context 'when the application already exists' do
       before do
         allow(CrimeApplication).to receive(:create!).with(
-          application: JSON.parse(payload)
+          submitted_details: JSON.parse(payload)
         ) { raise ActiveRecord::RecordNotUnique }
 
         api_request

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'create application' do
-  let(:application_id) { application.submitted_details['id'] }
+  let(:application_id) { application.submitted_application['id'] }
 
   let(:application) do
     instance_double(
       CrimeApplication,
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'create application' do
     context 'with a valid request' do
       before do
         allow(CrimeApplication).to receive(:create!).with(
-          submitted_details: JSON.parse(payload)
+          submitted_application: JSON.parse(payload)
         ).and_return(record)
 
         allow(
@@ -43,7 +43,7 @@ RSpec.describe 'create application' do
 
       it 'stores the application in the datastore' do
         expect(CrimeApplication).to have_received(:create!).with(
-          submitted_details: JSON.parse(payload)
+          submitted_application: JSON.parse(payload)
         )
       end
 
@@ -85,7 +85,7 @@ RSpec.describe 'create application' do
     context 'when the application already exists' do
       before do
         allow(CrimeApplication).to receive(:create!).with(
-          submitted_details: JSON.parse(payload)
+          submitted_application: JSON.parse(payload)
         ) { raise ActiveRecord::RecordNotUnique }
 
         api_request

--- a/spec/api/datastore/v1/applications/get_application_spec.rb
+++ b/spec/api/datastore/v1/applications/get_application_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'get application' do
-  let(:application_id) { application.submitted_details['id'] }
+  let(:application_id) { application.submitted_application['id'] }
 
   let(:application) do
     CrimeApplication.create(
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/applications/get_application_spec.rb
+++ b/spec/api/datastore/v1/applications/get_application_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'get application' do
-  let(:application_id) { application.application['id'] }
+  let(:application_id) { application.submitted_details['id'] }
 
   let(:application) do
-    CrimeApplication.new(
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    CrimeApplication.create(
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 
@@ -31,8 +31,8 @@ RSpec.describe 'get application' do
         expect(response).to have_http_status(:success)
       end
 
-      it 'returns the application details' do
-        expect(JSON.parse(response.body)).to match(application.application)
+      it "returns the application's details" do
+        expect(JSON.parse(response.body)['id']).to eq(application_id)
       end
 
       it 'returned details satisfy with schema' do

--- a/spec/api/datastore/v1/applications/list_applications_spec.rb
+++ b/spec/api/datastore/v1/applications/list_applications_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe 'list applications' do
     let(:applications) do
       [
         {
-          submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+          submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
           status: 'submitted', submitted_at: 1.day.ago, returned_at: nil
         },
         {
-          submitted_details: {},
+          submitted_application: {},
           status: 'returned', submitted_at: 1.week.ago, returned_at: Time.zone.now
         },
         {
-          submitted_details: {},
+          submitted_application: {},
           status: 'superseded', submitted_at: 1.month.ago, returned_at: 1.week.ago
         }
       ]
@@ -158,27 +158,27 @@ RSpec.describe 'list applications' do
       let(:applications) do
         [
           {
-            submitted_details: { submitted_at: 1.day.ago, returned_at: nil },
+            submitted_application: { submitted_at: 1.day.ago, returned_at: nil },
             status: 'submitted', submitted_at: 1.day.ago, returned_at: nil
           },
           {
-            submitted_details: { submitted_at: 2.days.ago, returned_at: nil },
+            submitted_application: { submitted_at: 2.days.ago, returned_at: nil },
             status: 'submitted', submitted_at: 2.days.ago, returned_at: nil
           },
           {
-            submitted_details: { submitted_at: 1.week.ago, returned_at: 8.days.ago },
+            submitted_application: { submitted_at: 1.week.ago, returned_at: 8.days.ago },
             status: 'returned', submitted_at: 1.week.ago, returned_at: 8.days.ago
           },
           {
-            submitted_details: { submitted_at: 2.weeks.ago, returned_at: 5.days.ago },
+            submitted_application: { submitted_at: 2.weeks.ago, returned_at: 5.days.ago },
             status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago
           },
           {
-            submitted_details: { submitted_at: 1.month.ago, returned_at: 3.weeks.ago },
+            submitted_application: { submitted_at: 1.month.ago, returned_at: 3.weeks.ago },
             status: 'superseded', submitted_at: 1.month.ago, returned_at: 3.weeks.ago
           },
           {
-            submitted_details: { submitted_at: 2.months.ago, returned_at: 7.weeks.ago },
+            submitted_application: { submitted_at: 2.months.ago, returned_at: 7.weeks.ago },
             status: 'superseded', submitted_at: 2.months.ago, returned_at: 7.weeks.ago
           },
         ]

--- a/spec/api/datastore/v1/applications/list_applications_spec.rb
+++ b/spec/api/datastore/v1/applications/list_applications_spec.rb
@@ -83,15 +83,15 @@ RSpec.describe 'list applications' do
     let(:applications) do
       [
         {
-          application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+          submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
           status: 'submitted', submitted_at: 1.day.ago, returned_at: nil
         },
         {
-          application: {},
+          submitted_details: {},
           status: 'returned', submitted_at: 1.week.ago, returned_at: Time.zone.now
         },
         {
-          application: {},
+          submitted_details: {},
           status: 'superseded', submitted_at: 1.month.ago, returned_at: 1.week.ago
         }
       ]
@@ -158,27 +158,27 @@ RSpec.describe 'list applications' do
       let(:applications) do
         [
           {
-            application: { submitted_at: 1.day.ago, returned_at: nil },
+            submitted_details: { submitted_at: 1.day.ago, returned_at: nil },
             status: 'submitted', submitted_at: 1.day.ago, returned_at: nil
           },
           {
-            application: { submitted_at: 2.days.ago, returned_at: nil },
+            submitted_details: { submitted_at: 2.days.ago, returned_at: nil },
             status: 'submitted', submitted_at: 2.days.ago, returned_at: nil
           },
           {
-            application: { submitted_at: 1.week.ago, returned_at: 8.days.ago },
+            submitted_details: { submitted_at: 1.week.ago, returned_at: 8.days.ago },
             status: 'returned', submitted_at: 1.week.ago, returned_at: 8.days.ago
           },
           {
-            application: { submitted_at: 2.weeks.ago, returned_at: 5.days.ago },
+            submitted_details: { submitted_at: 2.weeks.ago, returned_at: 5.days.ago },
             status: 'returned', submitted_at: 2.weeks.ago, returned_at: 5.days.ago
           },
           {
-            application: { submitted_at: 1.month.ago, returned_at: 3.weeks.ago },
+            submitted_details: { submitted_at: 1.month.ago, returned_at: 3.weeks.ago },
             status: 'superseded', submitted_at: 1.month.ago, returned_at: 3.weeks.ago
           },
           {
-            application: { submitted_at: 2.months.ago, returned_at: 7.weeks.ago },
+            submitted_details: { submitted_at: 2.months.ago, returned_at: 7.weeks.ago },
             status: 'superseded', submitted_at: 2.months.ago, returned_at: 7.weeks.ago
           },
         ]

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'get application ready for maat' do
 
     let(:application) do
       CrimeApplication.create(
-        submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+        submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
         review_status: :ready_for_assessment,
         id: SecureRandom.uuid,
         submitted_at: 1.day.ago
       )
     end
 
-    let(:application_usn) { application.submitted_details['reference'] }
+    let(:application_usn) { application.submitted_application['reference'] }
     let(:maat_application) { JSON.parse(response.body) }
 
     it_behaves_like 'an authorisable endpoint', %w[maat-adapter] do
@@ -27,29 +27,29 @@ RSpec.describe 'get application ready for maat' do
 
       let(:expected_offence_class) do
         Utils::OffenceClassCalculator.new(
-          offences: application.submitted_details['case_details']['offences']
+          offences: application.submitted_application['case_details']['offences']
         ).offence_class
       end
 
       let(:expected_case_details) do
         {
-          'appeal_maat_id' => application.submitted_details['case_details']['appeal_maat_id'],
-          'case_type' => application.submitted_details['case_details']['case_type'],
-          'hearing_court_name' => application.submitted_details['case_details']['hearing_court_name'],
-          'hearing_date' => application.submitted_details['case_details']['hearing_date'],
+          'appeal_maat_id' => application.submitted_application['case_details']['appeal_maat_id'],
+          'case_type' => application.submitted_application['case_details']['case_type'],
+          'hearing_court_name' => application.submitted_application['case_details']['hearing_court_name'],
+          'hearing_date' => application.submitted_application['case_details']['hearing_date'],
           'offence_class' => expected_offence_class,
-          'urn' => application.submitted_details['case_details']['urn'],
+          'urn' => application.submitted_application['case_details']['urn'],
         }
       end
 
       let(:expected_maat_application) do
         {
-          'reference' => application.submitted_details['reference'],
-          'client_details' => application.submitted_details['client_details'],
-          'provider_details' => application.submitted_details['provider_details'],
+          'reference' => application.submitted_application['reference'],
+          'client_details' => application.submitted_application['client_details'],
+          'provider_details' => application.submitted_application['provider_details'],
           'submitted_at' => application['submitted_at'].iso8601,
-          'date_stamp' => application.submitted_details['date_stamp'],
-          'interests_of_justice' => application.submitted_details['interests_of_justice'],
+          'date_stamp' => application.submitted_application['date_stamp'],
+          'interests_of_justice' => application.submitted_application['interests_of_justice'],
           'case_details' => expected_case_details,
           'schema_version' => 1.0,
           'id' => application.id

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'get application ready for maat' do
 
     let(:application) do
       CrimeApplication.create(
-        application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+        submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
         review_status: :ready_for_assessment,
         id: SecureRandom.uuid,
         submitted_at: 1.day.ago
       )
     end
 
-    let(:application_usn) { application.application['reference'] }
+    let(:application_usn) { application.submitted_details['reference'] }
     let(:maat_application) { JSON.parse(response.body) }
 
     it_behaves_like 'an authorisable endpoint', %w[maat-adapter] do
@@ -26,28 +26,30 @@ RSpec.describe 'get application ready for maat' do
       end
 
       let(:expected_offence_class) do
-        Utils::OffenceClassCalculator.new(offences: application.application['case_details']['offences']).offence_class
+        Utils::OffenceClassCalculator.new(
+          offences: application.submitted_details['case_details']['offences']
+        ).offence_class
       end
 
       let(:expected_case_details) do
         {
-          'appeal_maat_id' => application.application['case_details']['appeal_maat_id'],
-          'case_type' => application.application['case_details']['case_type'],
-          'hearing_court_name' => application.application['case_details']['hearing_court_name'],
-          'hearing_date' => application.application['case_details']['hearing_date'],
+          'appeal_maat_id' => application.submitted_details['case_details']['appeal_maat_id'],
+          'case_type' => application.submitted_details['case_details']['case_type'],
+          'hearing_court_name' => application.submitted_details['case_details']['hearing_court_name'],
+          'hearing_date' => application.submitted_details['case_details']['hearing_date'],
           'offence_class' => expected_offence_class,
-          'urn' => application.application['case_details']['urn'],
+          'urn' => application.submitted_details['case_details']['urn'],
         }
       end
 
       let(:expected_maat_application) do
         {
-          'reference' => application.application['reference'],
-          'client_details' => application.application['client_details'],
-          'provider_details' => application.application['provider_details'],
+          'reference' => application.submitted_details['reference'],
+          'client_details' => application.submitted_details['client_details'],
+          'provider_details' => application.submitted_details['provider_details'],
           'submitted_at' => application['submitted_at'].iso8601,
-          'date_stamp' => application.application['date_stamp'],
-          'interests_of_justice' => application.application['interests_of_justice'],
+          'date_stamp' => application.submitted_details['date_stamp'],
+          'interests_of_justice' => application.submitted_details['interests_of_justice'],
           'case_details' => expected_case_details,
           'schema_version' => 1.0,
           'id' => application.id

--- a/spec/api/datastore/v1/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/complete_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'complete application' do
   let(:application) do
     CrimeApplication.create!(
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/complete_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'complete application' do
   let(:application) do
     CrimeApplication.create!(
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/reviewing/mark_as_ready_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/mark_as_ready_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'ready for assessment application' do
   let(:application) do
     CrimeApplication.create!(
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/reviewing/mark_as_ready_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/mark_as_ready_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'ready for assessment application' do
   let(:application) do
     CrimeApplication.create!(
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/return_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'return application' do
   let(:application) do
     CrimeApplication.create!(
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/reviewing/return_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/return_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'return application' do
   let(:application) do
     CrimeApplication.create!(
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/api/datastore/v1/searching/filter_by_date_of_birth_spec.rb
+++ b/spec/api/datastore/v1/searching/filter_by_date_of_birth_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe 'filter search by applicant date of birth' do
   before do
     CrimeApplication.insert_all(
       [
-        { status: 'submitted', application: {} },
-        { status: 'submitted', application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) },
-        { status: 'returned', application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+        { status: 'submitted', submitted_details: {} },
+        { status: 'submitted', submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) },
+        { status: 'returned', submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
       ]
     )
 

--- a/spec/api/datastore/v1/searching/filter_by_date_of_birth_spec.rb
+++ b/spec/api/datastore/v1/searching/filter_by_date_of_birth_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe 'filter search by applicant date of birth' do
   before do
     CrimeApplication.insert_all(
       [
-        { status: 'submitted', submitted_details: {} },
-        { status: 'submitted', submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) },
-        { status: 'returned', submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+        { status: 'submitted', submitted_application: {} },
+        { status: 'submitted', submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) },
+        { status: 'returned', submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
       ]
     )
 

--- a/spec/api/datastore/v1/searching/filter_by_submitted_at_spec.rb
+++ b/spec/api/datastore/v1/searching/filter_by_submitted_at_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'searches filter by submitted_at' do
   before do
     CrimeApplication.insert_all(
       [
-        { submitted_at: 3.days.ago, submitted_details: { reference: 101 } },
-        { submitted_at: 2.days.ago, submitted_details: { reference: 102 } },
-        { submitted_at: 1.day.ago, submitted_details: { reference: 103 } }
+        { submitted_at: 3.days.ago, submitted_application: { reference: 101 } },
+        { submitted_at: 2.days.ago, submitted_application: { reference: 102 } },
+        { submitted_at: 1.day.ago, submitted_application: { reference: 103 } }
       ]
     )
 

--- a/spec/api/datastore/v1/searching/filter_by_submitted_at_spec.rb
+++ b/spec/api/datastore/v1/searching/filter_by_submitted_at_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'searches filter by submitted_at' do
   before do
     CrimeApplication.insert_all(
       [
-        { submitted_at: 3.days.ago, application: { reference: 101 } },
-        { submitted_at: 2.days.ago, application: { reference: 102 } },
-        { submitted_at: 1.day.ago, application: { reference: 103 } }
+        { submitted_at: 3.days.ago, submitted_details: { reference: 101 } },
+        { submitted_at: 2.days.ago, submitted_details: { reference: 102 } },
+        { submitted_at: 1.day.ago, submitted_details: { reference: 103 } }
       ]
     )
 

--- a/spec/api/datastore/v1/searching/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v1/searching/search_by_name_and_reference_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'search with text' do
     CrimeApplication.insert_all(
       details.map do |first_name, last_name, reference|
         {
-          submitted_details: {
+          submitted_application: {
             client_details: {
               applicant: { first_name:, last_name: }
             },

--- a/spec/api/datastore/v1/searching/search_by_name_and_reference_spec.rb
+++ b/spec/api/datastore/v1/searching/search_by_name_and_reference_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'search with text' do
     CrimeApplication.insert_all(
       details.map do |first_name, last_name, reference|
         {
-          application: {
+          submitted_details: {
             client_details: {
               applicant: { first_name:, last_name: }
             },

--- a/spec/api/datastore/v1/searching/sorting_spec.rb
+++ b/spec/api/datastore/v1/searching/sorting_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Sorting applications' do
   let(:applications) do
     [
       {
-        application: {
+        submitted_details: {
           client_details: {
             applicant: { first_name: 'jim', last_name: 'Halpert' }
           }
@@ -33,7 +33,7 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: nil,
       },
       {
-        application: {
+        submitted_details: {
           client_details: {
             applicant: { first_name: 'Michael', last_name: 'Scott' }
           }
@@ -42,12 +42,12 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: nil
       },
       {
-        application: {},
+        submitted_details: {},
         status: 'returned', submitted_at: 1.week.ago, returned_at: 8.days.ago,
         reviewed_at: 8.days.ago
       },
       {
-        application: {
+        submitted_details: {
           client_details: {
             applicant: { first_name: '', last_name: 'schrute' }
           }
@@ -56,7 +56,7 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: 5.days.ago
       },
       {
-        application: {
+        submitted_details: {
           client_details: {
             applicant: { first_name: 'Stanley', last_name: 'hudSon' }
           }

--- a/spec/api/datastore/v1/searching/sorting_spec.rb
+++ b/spec/api/datastore/v1/searching/sorting_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Sorting applications' do
   let(:applications) do
     [
       {
-        submitted_details: {
+        submitted_application: {
           client_details: {
             applicant: { first_name: 'jim', last_name: 'Halpert' }
           }
@@ -33,7 +33,7 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: nil,
       },
       {
-        submitted_details: {
+        submitted_application: {
           client_details: {
             applicant: { first_name: 'Michael', last_name: 'Scott' }
           }
@@ -42,12 +42,12 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: nil
       },
       {
-        submitted_details: {},
+        submitted_application: {},
         status: 'returned', submitted_at: 1.week.ago, returned_at: 8.days.ago,
         reviewed_at: 8.days.ago
       },
       {
-        submitted_details: {
+        submitted_application: {
           client_details: {
             applicant: { first_name: '', last_name: 'schrute' }
           }
@@ -56,7 +56,7 @@ RSpec.describe 'Sorting applications' do
         reviewed_at: 5.days.ago
       },
       {
-        submitted_details: {
+        submitted_application: {
           client_details: {
             applicant: { first_name: 'Stanley', last_name: 'hudSon' }
           }

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe CrimeApplication do
   let(:valid_attributes) do
-    { application: application_attributes }
+    { submitted_details: application_attributes }
   end
 
   let(:application_attributes) do
@@ -41,6 +41,12 @@ describe CrimeApplication do
         expect(
           application.submitted_at
         ).to eq(application_attributes['submitted_at'])
+      end
+
+      it 'has an offence class' do
+        expect(
+          application.offence_class
+        ).to be_nil
       end
     end
   end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe CrimeApplication do
   let(:valid_attributes) do
-    { submitted_details: application_attributes }
+    { submitted_application: application_attributes }
   end
 
   let(:application_attributes) do

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -7,7 +7,7 @@ describe Events::Submission do
       id: 'f7b429cc',
       submitted_at: DateTime.parse('2023-02-27'),
       reference: 673_209,
-      submitted_details: { 'parent_id' => '9a123b' }
+      submitted_application: { 'parent_id' => '9a123b' }
     )
   end
 

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -7,7 +7,7 @@ describe Events::Submission do
       id: 'f7b429cc',
       submitted_at: DateTime.parse('2023-02-27'),
       reference: 673_209,
-      application: { 'parent_id' => '9a123b' }
+      submitted_details: { 'parent_id' => '9a123b' }
     )
   end
 

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Operations::ReturnApplication do
   before do
     CrimeApplication.create(
-      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Operations::ReturnApplication do
   before do
     CrimeApplication.create(
-      application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+      submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
 

--- a/spec/services/operations/supersede_application_spec.rb
+++ b/spec/services/operations/supersede_application_spec.rb
@@ -8,7 +8,7 @@ describe Operations::SupersedeApplication do
   describe '#call' do
     before do
       CrimeApplication.create(
-        submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read),
+        submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read),
         status: :returned,
       )
     end

--- a/spec/services/operations/supersede_application_spec.rb
+++ b/spec/services/operations/supersede_application_spec.rb
@@ -8,7 +8,7 @@ describe Operations::SupersedeApplication do
   describe '#call' do
     before do
       CrimeApplication.create(
-        application: JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read),
+        submitted_details: JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_returned').read),
         status: :returned,
       )
     end

--- a/spec/services/utils/offence_class_calculator_spec.rb
+++ b/spec/services/utils/offence_class_calculator_spec.rb
@@ -76,7 +76,7 @@ describe Utils::OffenceClassCalculator do
 
     describe 'failsafe checks for required types' do
       it 'uses a valid offence class ranking' do
-        expect(described_class::OFFENCE_CLASS_RANKING).to eq(%w[a k g b i j d c h f e].freeze)
+        expect(Types::OffenceClass.values).to eq(%w[A K G B I J D C H F E].freeze)
       end
     end
   end

--- a/spec/services/utils/offence_class_calculator_spec.rb
+++ b/spec/services/utils/offence_class_calculator_spec.rb
@@ -73,11 +73,5 @@ describe Utils::OffenceClassCalculator do
         expect(subject.offence_class).to be_nil
       end
     end
-
-    describe 'failsafe checks for required types' do
-      it 'uses a valid offence class ranking' do
-        expect(Types::OffenceClass.values).to eq(%w[A K G B I J D C H F E].freeze)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Description of change

This PR adds an an offence class field to the crime_application table and when an application is created, an overall offence class is calculated and saved. This field is then returned as part of the crime and maat application data. 

A migration is also added to rename the submitted application json data in the crime_applications table from `application` to `submitted_details` to make the distinction between submitted data from apply and application data in the datastore clearer.

An offence class type (`Types::OffenceClass`) has also been added to the schema repo so the offence class calculator is refactored to use the type. 

## Link to relevant ticket

[CRIMRE-311](https://dsdmoj.atlassian.net/jira/software/c/projects/CRIMRE/boards/960?modal=detail&selectedIssue=CRIMRE-311)

## Notes for reviewer / how to test
A lot of the changes is just renaming `application` to `submitted_details` 😄

[CRIMRE-311]: https://dsdmoj.atlassian.net/browse/CRIMRE-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ