### PR TITLE
CRIMAP-21 Add basic prometheus rules

### DIFF
--- a/config/kubernetes/production/prometheus.yml
+++ b/config/kubernetes/production/prometheus.yml
@@ -1,0 +1,111 @@
+# Prometheus Alerts
+#
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html
+#
+# Note: we are using a regex in the namespace to filter and trigger alerts
+# in both, staging and production environments.
+#
+# To see the current alerts in this namespace:
+#   kubectl describe prometheusrule -n laa-criminal-applications-datastore-production
+#
+# Alerts will be sent to the slack channel: #laa-crime-apply-alerts
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-production
+  namespace: laa-criminal-applications-datastore-production
+  labels:
+    role: alert-rules
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: CrimeApplyDatastore-NamespaceMissing
+      expr: >-
+        absent(kube_namespace_created{namespace=~"^laa-criminal-applications-datastore.*"})
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Namespace `{{ $labels.namespace }}` is missing.
+
+    - alert: CrimeApplyDatastore-DeploymentReplicasMismatch
+      expr: >-
+        kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"^laa-criminal-applications-datastore.*"}
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Deployment `{{ $labels.deployment }}` has not matched the expected number of replicas for more than 15m.
+
+    - alert: CrimeApplyDatastore-KubePodCrashLooping
+      expr: >-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^laa-criminal-applications-datastore.*"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Pod `{{ $labels.pod }}` has been restarting in `{{ $labels.namespace }}` for the last 5m.
+
+    - alert: CrimeApplyDatastore-KubeQuotaExceeded
+      expr: >-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used", namespace=~"^laa-criminal-applications-datastore.*"} 
+        / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) > 90
+      for: 5m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Namespace `{{ $labels.namespace }}` is using {{ printf "%0.0f" $value}}% of its {{ $labels.resource }} quota.
+
+    - alert: CrimeApplyDatastore-KubePodNotReady
+      expr: >-
+        sum by (namespace, pod) (kube_pod_status_phase{namespace=~"^laa-criminal-applications-datastore.*", job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 1h
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Pod `{{ $labels.pod }}` in `{{ $labels.namespace }}` has been in a non-ready state for longer than 1h.
+
+    - alert: CrimeApplyDatastore-SlowResponses
+      expr: >-
+        avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace=~"^laa-criminal-applications-datastore.*"}[5m])
+        / rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"^laa-criminal-applications-datastore.*"}[5m]) > 0) 
+        by (exported_namespace) > 3
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Namespace `{{ $labels.exported_namespace }}` is serving slow responses.
+
+    - alert: CrimeApplyDatastore-Ingress4XX
+      expr: >-
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"^laa-criminal-applications-datastore.*", status=~"4.."}[1m]) * 60 > 0) 
+        by (exported_namespace)
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Namespace `{{ $labels.exported_namespace }}` is serving 4XX responses.
+
+    - alert: CrimeApplyDatastore-Ingress5XX
+      expr: >-
+        avg(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace=~"^laa-criminal-applications-datastore.*", status=~"5.."}[1m]) * 60 > 0) 
+        by (exported_namespace)
+      for: 1m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Namespace `{{ $labels.exported_namespace }}` is serving 5XX responses.
+
+    - alert: CrimeApplyDatastore-DLQNotEmpty
+      expr: >-
+        sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name=~"^laa-crime-apply-(staging|production)-application-events-dlq"} offset 5m) 
+        by (queue_name) > 0
+      for: 10m
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Dead letter queue `{{ $labels.queue_name }}` has {{ $value }} message(s).


### PR DESCRIPTION
## Description of change
This is a first bunch of basic prometheus rules that will alert us in the alerts channel whenever they fire.

There is scope to add some more or tweak them so for now I'm adding them here in the code repo, but once we are comfortable with them, we should move this file from the code repo to the infra repo (`cloud-platform-environments`).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-21
https://dsdmoj.atlassian.net/browse/CRIMRE-225