### PR TITLE
Add trivy scan prometheus alert and dashboard urls

### DIFF
--- a/config/kubernetes/production/prometheus.yml
+++ b/config/kubernetes/production/prometheus.yml
@@ -44,7 +44,7 @@ spec:
     - alert: CrimeApplyDatastore-KubePodCrashLooping
       expr: >-
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace=~"^laa-criminal-applications-datastore.*"}[5m]) > 0
-      for: 1m
+      for: 5m
       labels:
         severity: laa-crime-apply-alerts
       annotations:
@@ -79,6 +79,7 @@ spec:
         severity: laa-crime-apply-alerts
       annotations:
         message: Namespace `{{ $labels.exported_namespace }}` is serving slow responses.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/f1e13059dfd23fdcaf479f4fa833f92610c2dfa5/kubernetes-ingress-traffic?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.exported_namespace }}&var-ingress={{ $labels.ingress }}
 
     - alert: CrimeApplyDatastore-Ingress4XX
       expr: >-
@@ -89,6 +90,7 @@ spec:
         severity: laa-crime-apply-alerts
       annotations:
         message: Namespace `{{ $labels.exported_namespace }}` is serving 4XX responses.
+        dashboard_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/?_g=(time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.request_path),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.kubernetes_namespace,negate:!f,params:(query:{{ $labels.exported_namespace }}),type:phrase),query:(match_phrase:(log_processed.kubernetes_namespace:{{ $labels.exported_namespace }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.status,negate:!f,params:(gte:400,lt:500),type:range),range:(log_processed.status:(gte:400,lt:500)))),index:'8a728bc0-00eb-11ec-9062-27aa363b66a2')
 
     - alert: CrimeApplyDatastore-Ingress5XX
       expr: >-
@@ -99,6 +101,18 @@ spec:
         severity: laa-crime-apply-alerts
       annotations:
         message: Namespace `{{ $labels.exported_namespace }}` is serving 5XX responses.
+        dashboard_url: https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/?_g=(time:(from:now-24h,to:now))&_a=(columns:!(log_processed.status,log_processed.request_path),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.kubernetes_namespace,negate:!f,params:(query:{{ $labels.exported_namespace }}),type:phrase),query:(match_phrase:(log_processed.kubernetes_namespace:{{ $labels.exported_namespace }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',key:log_processed.status,negate:!f,params:(gte:500,lt:600),type:range),range:(log_processed.status:(gte:500,lt:600)))),index:'8a728bc0-00eb-11ec-9062-27aa363b66a2')
+
+    - alert: CrimeApplyDatastore-TrivyVulns
+      expr: >-
+        sum(trivy_image_vulnerabilities{namespace=~"^laa-criminal-applications-datastore.*", severity=~"Critical|High|Medium"} > 0) 
+        by (namespace, image_tag, severity)
+      for: 1h
+      labels:
+        severity: laa-crime-apply-alerts
+      annotations:
+        message: Image `{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.severity }} vulnerabilities.
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/trivy_starboard_operator123/trivy-operator-image-vulnerability?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.namespace }}
 
     - alert: CrimeApplyDatastore-DLQNotEmpty
       expr: >-
@@ -109,3 +123,4 @@ spec:
         severity: laa-crime-apply-alerts
       annotations:
         message: Dead letter queue `{{ $labels.queue_name }}` has {{ $value }} message(s).
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/AWSSQS000/aws-sqs?orgId=1&from=now-24h&to=now&var-datasource=Cloudwatch&var-region=default&var-queue={{ $labels.queue_name }}


### PR DESCRIPTION
## Description of change
Added a new alert for Trivy reported vulnerabilities, and dashboard urls to as many alerts as possible (where available).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-26

## Notes for reviewer / how to test
