### PR TITLE
Use v0.1.9 of laa schema gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.8'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.1.9'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5df43ce58a62d0c4fbbf5ce8521e4967e09c9e30
-  tag: v0.1.8
+  revision: d9802d263c9a0fb34c6cfdb10473567c592f34a9
+  tag: v0.1.9
   specs:
-    laa-criminal-legal-aid-schemas (0.1.7)
+    laa-criminal-legal-aid-schemas (0.1.9)
       dry-struct
       json-schema (~> 3.0.0)
 


### PR DESCRIPTION
## Description of change
Use the latest version of the schema gem, which includes enums form several attributes and will not allow the submission of multi class offences.

## Link to relevant ticket
[CRIMRE-333](https://dsdmoj.atlassian.net/browse/CRIMRE-333)

## Notes for reviewer / how to test


[CRIMRE-333]: https://dsdmoj.atlassian.net/browse/CRIMRE-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ