### PR TITLE
CRIMAP-385 Remove dependency on unneeded fixtures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5e8f4dd9b08185ce8801bd64141187df2519b42f
-  tag: v0.2.0
+  revision: 0a80f2d03dd5fdffafbfcfababa518c186d33a00
+  tag: v0.2.1
   specs:
-    laa-criminal-legal-aid-schemas (0.2.0)
+    laa-criminal-legal-aid-schemas (0.2.1)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
   end
 
   let(:submitted_application) do
-    JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('parent_id' => SecureRandom.uuid)
+    LaaCrimeSchemas.fixture(1.0) { |json| json.merge('parent_id' => SecureRandom.uuid) }
   end
 
   context 'when retrieved from the submitted details' do

--- a/spec/api/datastore/entities/v1/search_result_spec.rb
+++ b/spec/api/datastore/entities/v1/search_result_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   let(:review_status) { 'assessment_completed' }
 
   let(:submitted_application) do
-    JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_invalid').read).merge('parent_id' => parent_id)
+    LaaCrimeSchemas.fixture(1.0) { |json| json.merge('parent_id' => parent_id) }
   end
 
   it 'represents submitted_at in is8601' do

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'create application' do
       end
 
       let(:payload) do
-        LaaCrimeSchemas.fixture(1.0, name: 'application_invalid').read
+        LaaCrimeSchemas.fixture(1.0) { |json| json.merge('reference' => nil) }.to_json
       end
 
       it 'does not store the application' do
@@ -125,7 +125,9 @@ RSpec.describe 'create application' do
       end
 
       it 'returns error information' do
-        expect(response.body).to include('failed_attribute')
+        expect(response.body).to include(
+          "The property '#/reference' of type null did not match the following type: number in schema"
+        )
       end
     end
   end

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -54,7 +54,14 @@ describe CrimeApplication do
 
         context 'when offence class can be determined' do
           let(:application_attributes) do
-            JSON.parse(LaaCrimeSchemas.fixture(1.0, name: 'application_completed').read)
+            LaaCrimeSchemas.fixture(1.0) do |json|
+              json.deep_merge(
+                'case_details' => {
+                  # For the sake of this test, only `offence_class` attrs are required
+                  'offences' => [{ 'offence_class' => 'C' }, { 'offence_class' => 'F' }]
+                }
+              )
+            end
           end
 
           it 'has an offence class' do


### PR DESCRIPTION
## Description of change
This is part of an overall work to rationalise and remove any unneeded, unused, or superfluous fixtures, as these grow a bit out of hand for a while for no good reason.

On Datastore I've detected a couple superfluous fixtures: application_completed.json and application_invalid.json

These have been replaced by the overarching `application.json`, merging or tweaking the JSON where necessary for the specific test scenario.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-385

## Notes for reviewer / how to test
