### PR TITLE
CRIMAP-387 Return list of pruned applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.2.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 0a80f2d03dd5fdffafbfcfababa518c186d33a00
-  tag: v0.2.1
+  revision: 183785d967669e94009623978e094de03e910b12
+  tag: v0.3.0
   specs:
-    laa-criminal-legal-aid-schemas (0.2.1)
+    laa-criminal-legal-aid-schemas (0.3.0)
       dry-struct
       json-schema (~> 3.0.0)
 

--- a/app/api/datastore/entities/v1/pruned_application.rb
+++ b/app/api/datastore/entities/v1/pruned_application.rb
@@ -1,0 +1,29 @@
+module Datastore
+  module Entities
+    module V1
+      class PrunedApplication < CrimeApplication
+        unexpose :provider_details,
+                 :case_details,
+                 :interests_of_justice,
+                 :return_details,
+                 :date_stamp,
+                 :ioj_passport,
+                 :means_passport
+
+        expose :client_details do
+          expose :applicant do
+            expose :applicant_details, merge: true
+          end
+        end
+
+        private
+
+        def applicant_details
+          return {} if client_details.nil?
+
+          client_details['applicant'].slice('first_name', 'last_name')
+        end
+      end
+    end
+  end
+end

--- a/app/api/datastore/v1/applications.rb
+++ b/app/api/datastore/v1/applications.rb
@@ -28,7 +28,7 @@ module Datastore
           end
         end
 
-        desc 'Return applications with pagination.'
+        desc 'Return a pruned version of the applications with pagination.'
         route_setting :authorised_consumers, %w[crime-apply]
         params do
           use :sorting
@@ -55,7 +55,7 @@ module Datastore
             **declared(params).symbolize_keys
           ).call
 
-          present :records, collection, with: Datastore::Entities::V1::CrimeApplication
+          present :records, collection, with: Datastore::Entities::V1::PrunedApplication
           present :pagination, collection, with: Datastore::Entities::V1::Pagination
         end
       end

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'create application' do
 
       it 'returns error information' do
         expect(response.body).to include(
-          "The property '#/reference' of type null did not match the following type: number in schema"
+          "The property '#/reference' of type null did not match the following type: integer in schema"
         )
       end
     end

--- a/spec/api/datastore/v1/applications/list_applications_spec.rb
+++ b/spec/api/datastore/v1/applications/list_applications_spec.rb
@@ -103,8 +103,22 @@ RSpec.describe 'list applications' do
 
     it 'is an array of valid crime application details' do
       expect(
-        LaaCrimeSchemas::Validator.new(records.first, version: 1.0)
+        LaaCrimeSchemas::Validator.new(records.first, version: 1.0, schema_name: 'pruned_application')
       ).to be_valid
+    end
+
+    describe 'pruned details' do
+      let(:record) { records.first }
+
+      context 'without unneeded attributes' do
+        %w[
+          provider_details case_details interests_of_justice return_details date_stamp ioj_passport means_passport
+        ].each do |name|
+          it "does not have `#{name}` attribute" do
+            expect(record.key?(name)).to be(false)
+          end
+        end
+      end
     end
 
     describe 'status filter' do
@@ -139,9 +153,6 @@ RSpec.describe 'list applications' do
 
         it 'returns only matching applications' do
           expect(records.size).to be(1)
-          expect(
-            records.first.dig('provider_details', 'office_code')
-          ).to eq('1A123B')
         end
       end
 


### PR DESCRIPTION
## Description of change
This uses the latest version of the schemas gem (v3.0.0) that supports a new type of schema/struct for a pruned application, reducing drastically the number of attributes returned in the `GET /applications` endpoint.

A new entity has been created to represent this pruned version of the applications, so it is independent of the "main" entity used in other endpoints.

Also, this endpoint is only used on Apply currently, to build the dashboard and paginate through applications, so there should be no impact on any other consumer (Review or MAAT).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-387

## Notes for reviewer / how to test
A PR on Apply is also require along with this work, to be deployed together.