### PR TITLE
CRIMAP-388 Bump schemas gem (stricter structs)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.3.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 183785d967669e94009623978e094de03e910b12
-  tag: v0.3.0
+  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
+  tag: v0.4.0
   specs:
-    laa-criminal-legal-aid-schemas (0.3.0)
-      dry-struct
-      json-schema (~> 3.0.0)
+    laa-criminal-legal-aid-schemas (0.4.0)
+      dry-struct (~> 1.6.0)
+      json-schema (~> 4.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -151,7 +151,7 @@ GEM
       reline (>= 0.3.0)
     jmespath (1.6.2)
     json (2.6.3)
-    json-schema (3.0.0)
+    json-schema (4.0.0)
       addressable (>= 2.8)
     jwt (2.7.0)
     kaminari-activerecord (1.2.2)

--- a/app/api/datastore/entities/v1/pruned_application.rb
+++ b/app/api/datastore/entities/v1/pruned_application.rb
@@ -6,7 +6,6 @@ module Datastore
                  :case_details,
                  :interests_of_justice,
                  :return_details,
-                 :date_stamp,
                  :ioj_passport,
                  :means_passport
 

--- a/spec/api/datastore/v1/applications/list_applications_spec.rb
+++ b/spec/api/datastore/v1/applications/list_applications_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'list applications' do
 
       context 'without unneeded attributes' do
         %w[
-          provider_details case_details interests_of_justice return_details date_stamp ioj_passport means_passport
+          provider_details case_details interests_of_justice return_details ioj_passport means_passport
         ].each do |name|
           it "does not have `#{name}` attribute" do
             expect(record.key?(name)).to be(false)

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -29,16 +29,20 @@ RSpec.describe 'get application ready for maat' do
         ).offence_class
       end
 
+      # rubocop:disable Layout/LineLength
       let(:expected_case_details) do
         {
-          'appeal_maat_id' => application.submitted_application['case_details']['appeal_maat_id'],
           'case_type' => application.submitted_application['case_details']['case_type'],
+          'appeal_maat_id' => application.submitted_application['case_details']['appeal_maat_id'],
+          'appeal_with_changes_maat_id' => application.submitted_application['case_details']['appeal_with_changes_maat_id'],
+          'appeal_with_changes_details' => application.submitted_application['case_details']['appeal_with_changes_details'],
           'hearing_court_name' => application.submitted_application['case_details']['hearing_court_name'],
           'hearing_date' => application.submitted_application['case_details']['hearing_date'],
           'offence_class' => expected_offence_class,
           'urn' => application.submitted_application['case_details']['urn'],
         }
       end
+      # rubocop:enable Layout/LineLength
 
       let(:expected_maat_application) do
         {


### PR DESCRIPTION
## Description of change
Note by merging this PR, many existing submitted applications in the datastore will stop working as their JSON representation will not "fit" into these more strict structs.

However at some point we had to do this, so we will be wiping the staging DB and start fresh, with no baggage.

Another PR will be raised on Apply that will also use this new schemas version, with any required tweaks to the tests.

It is possible Review also needs some tweaks.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-388

## Notes for reviewer / how to test
