### PR TITLE
CRIMAP-402 Initial work for redacting PII details

### DIFF
--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,0 +1,11 @@
+module Redactable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :personally_identifiable_details, dependent: :destroy
+
+    after_initialize Redacting::CallbacksWrapper
+    before_save      Redacting::CallbacksWrapper
+    after_save       Redacting::CallbacksWrapper
+  end
+end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,4 +1,6 @@
 class CrimeApplication < ApplicationRecord
+  include Redactable
+
   has_one :return_details, dependent: :destroy
 
   attr_readonly :submitted_application, :submitted_at, :id

--- a/app/models/personally_identifiable_details.rb
+++ b/app/models/personally_identifiable_details.rb
@@ -1,0 +1,5 @@
+class PersonallyIdentifiableDetails < ApplicationRecord
+  belongs_to :crime_application
+
+  attr_readonly :id, :protected_details
+end

--- a/app/services/redacting/base_redacting.rb
+++ b/app/services/redacting/base_redacting.rb
@@ -1,0 +1,37 @@
+module Redacting
+  class BaseRedacting
+    include Rules
+
+    def initialize(record)
+      @record = record
+    end
+
+    # :nocov:
+    def process!
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+
+    private
+
+    attr_reader :record
+
+    # Creates a deep nested hash out of an array of keys
+    # ['a', 'b', 'c'] => { 'a' => { 'b' => { 'c' => details } } }
+    def traverse(path, details)
+      path.reverse.inject(details) { |value, key| { key => value } }
+    end
+
+    def exposed_payload
+      record.submitted_application
+    end
+
+    def protected_payload
+      secure_store.protected_details
+    end
+
+    def secure_store
+      @secure_store ||= (record.personally_identifiable_details || record.build_personally_identifiable_details)
+    end
+  end
+end

--- a/app/services/redacting/callbacks_wrapper.rb
+++ b/app/services/redacting/callbacks_wrapper.rb
@@ -1,0 +1,19 @@
+module Redacting
+  class CallbacksWrapper
+    class << self
+      def after_initialize(record)
+        after_save(record) unless record.new_record?
+      end
+
+      def before_save(record)
+        Rails.logger.debug { "==> Redacting application ID #{record.id}" }
+        Redacting::Redact.new(record).process! if record.submitted_application_changed?
+      end
+
+      def after_save(record)
+        Rails.logger.debug { "==> Unredacting application ID #{record.id}" }
+        Redacting::Unredact.new(record).process!
+      end
+    end
+  end
+end

--- a/app/services/redacting/redact.rb
+++ b/app/services/redacting/redact.rb
@@ -1,0 +1,57 @@
+module Redacting
+  class Redact < BaseRedacting
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def process!
+      Rules.all.each do |path, rules|
+        path = path.split('.')
+        details = exposed_payload&.dig(*path)
+
+        next if details.blank?
+
+        fields = rules.fetch(:redact)
+        type   = rules.fetch(:type, :object)
+
+        details = case type
+                  when :object
+                    details.slice(*fields).compact_blank
+                  when :array
+                    details.map { |item| item.slice(*fields).compact_blank }
+                  else
+                    raise "unknown rule path type: #{type}"
+                  end
+
+        protect_and_redact(path, details)
+      end
+
+      true
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    private
+
+    def protect_and_redact(path, details)
+      protected_payload.deep_merge!(
+        traverse(path, details)
+      )
+
+      exposed_payload.deep_merge!(
+        traverse(path, redact(details.dup))
+      ) do |_key, original, redacted|
+        if original.is_a?(Array)
+          # Handle collection of hashes, for example `codefendants`
+          original.map.with_index { |item, index| item.deep_merge(redacted[index]) }
+        else
+          redacted
+        end
+      end
+    end
+
+    def redact(details)
+      if details.is_a?(Array)
+        details.map { |item| redact(item.dup) }
+      else
+        details.each_key { |key| details[key] = REDACTED_KEYWORD }
+      end
+    end
+  end
+end

--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -1,0 +1,30 @@
+module Redacting
+  module Rules
+    PII_ATTRIBUTES = {
+      'provider_details' => {
+        redact: %w[legal_rep_first_name legal_rep_last_name legal_rep_telephone]
+      },
+      'client_details.applicant' => {
+        # TODO: `searchable_attributes` need `first_name` and `last_name`
+        # redact: %w[first_name last_name other_names nino telephone_number]
+        redact: %w[other_names nino telephone_number]
+      },
+      'client_details.applicant.home_address' => {
+        redact: %w[lookup_id address_line_one address_line_two]
+      },
+      'client_details.applicant.correspondence_address' => {
+        redact: %w[lookup_id address_line_one address_line_two]
+      },
+      'case_details.codefendants' => {
+        redact: %w[first_name last_name],
+        type: :array # [{}, {}, ...]
+      },
+    }.freeze
+
+    REDACTED_KEYWORD = '__redacted__'.freeze
+
+    def self.all
+      PII_ATTRIBUTES
+    end
+  end
+end

--- a/app/services/redacting/unredact.rb
+++ b/app/services/redacting/unredact.rb
@@ -1,0 +1,29 @@
+module Redacting
+  class Unredact < BaseRedacting
+    def process!
+      Rules.all.each_key do |path|
+        path = path.split('.')
+        details = protected_payload&.dig(*path)
+
+        unredact(path, details) if details.present?
+      end
+
+      true
+    end
+
+    private
+
+    def unredact(path, details)
+      exposed_payload.deep_merge!(
+        traverse(path, details)
+      ) do |_key, redacted, original|
+        if redacted.is_a?(Array)
+          # Handle collection of hashes, for example `codefendants`
+          redacted.map.with_index { |item, index| item.deep_merge(original[index]) }
+        else
+          original
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20230606112337_create_personally_identifiable_details.rb
+++ b/db/migrate/20230606112337_create_personally_identifiable_details.rb
@@ -1,0 +1,8 @@
+class CreatePersonallyIdentifiableDetails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :personally_identifiable_details, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: true, index: { unique: true }
+      t.jsonb :protected_details, null: false, default: {}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_06_112337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -39,6 +39,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
   end
 
+  create_table "personally_identifiable_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id"
+    t.jsonb "protected_details", default: {}, null: false
+    t.index ["crime_application_id"], name: "index_personally_identifiable_details_on_crime_application_id", unique: true
+  end
+
   create_table "return_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "reason", null: false
     t.text "details"
@@ -48,5 +54,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
     t.index ["crime_application_id"], name: "index_return_details_on_crime_application_id"
   end
 
+  add_foreign_key "personally_identifiable_details", "crime_applications"
   add_foreign_key "return_details", "crime_applications"
 end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+describe Redacting::Redact do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { CrimeApplication.new(submitted_application:) }
+  let(:submitted_application) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+
+  # rubocop:disable Layout/FirstHashElementIndentation, RSpec/ExampleLength
+  describe 'redacting of a submitted application' do
+    let(:redacted) { crime_application.submitted_application }
+
+    before do
+      subject.process!
+    end
+
+    context 'with provider details' do
+      let(:provider_details) { redacted['provider_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(provider_details).to eq({
+          'office_code' => '1A123B',
+          'provider_email' => 'provider@example.com',
+          'legal_rep_first_name' => '__redacted__',
+          'legal_rep_last_name' => '__redacted__',
+          'legal_rep_telephone' => '__redacted__',
+        })
+      end
+    end
+
+    context 'with client details' do
+      let(:client_details) { redacted['client_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(client_details['applicant']).to eq({
+          'first_name' => 'Kit',
+          'last_name' => 'Pound',
+          'nino' => '__redacted__',
+          'date_of_birth' => '2001-06-09',
+          'telephone_number' => '__redacted__',
+          'correspondence_address_type' => 'home_address',
+          'home_address' => {
+            'lookup_id' => nil,
+            'address_line_one' => '__redacted__',
+            'address_line_two' => '__redacted__',
+            'city' => 'Some nice city',
+            'country' => 'United Kingdom',
+            'postcode' => 'SW1A 2AA',
+          },
+          'correspondence_address' => nil
+        })
+      end
+    end
+
+    context 'with case details' do
+      let(:case_details) { redacted['case_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(case_details['codefendants']).to eq(
+          [{
+            'first_name' => '__redacted__',
+            'last_name' => '__redacted__',
+            'conflict_of_interest' => 'yes'
+          }]
+        )
+      end
+    end
+  end
+
+  describe 'for blank or null attributes' do
+    let(:submitted_application) do
+      LaaCrimeSchemas.fixture(1.0) do |json|
+        json.deep_merge(
+          'client_details' => { 'applicant' => { 'other_names' => '', 'nino' => nil } }
+        )
+      end
+    end
+
+    let(:redacted) { crime_application.submitted_application }
+    let(:client_details) { redacted['client_details'] }
+
+    it 'does not redact them, keep the original value' do
+      subject.process!
+
+      expect(client_details['applicant']).to match(
+        a_hash_including({
+          'other_names' => '',
+          'nino' => nil,
+          'telephone_number' => '__redacted__',
+        })
+      )
+    end
+  end
+  # rubocop:enable Layout/FirstHashElementIndentation, RSpec/ExampleLength
+
+  describe 'invalid rules' do
+    before do
+      allow(Redacting::Rules).to receive(:all).and_return(rules)
+    end
+
+    context 'when `redact` information is not found' do
+      let(:rules) do
+        { 'provider_details' => {} }
+      end
+
+      it 'raises a key not found error' do
+        expect { subject.process! }.to raise_error(KeyError, /key not found: :redact/)
+      end
+    end
+
+    context 'when the `type` is unrecognised' do
+      let(:rules) do
+        { 'provider_details' => { redact: %w[], type: :date } }
+      end
+
+      it 'raises a key not found error' do
+        expect { subject.process! }.to raise_error(RuntimeError, /unknown rule path type: date/)
+      end
+    end
+  end
+end

--- a/spec/services/redacting/unredact_spec.rb
+++ b/spec/services/redacting/unredact_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe Redacting::Unredact do
+  let(:submitted_application) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+
+  let(:app_a) { CrimeApplication.new(submitted_application:) } # to be redacted
+  let(:app_b) { CrimeApplication.new(submitted_application:) } # remains unredacted
+
+  describe 'unredacting of a submitted application' do
+    it 'matches the original application' do
+      # redact one application
+      Redacting::Redact.new(app_a).process!
+
+      # sanity check it has been redacted
+      expect(
+        app_a.submitted_application.dig('client_details', 'applicant')
+      ).to match(a_hash_including({ 'nino' => '__redacted__' }))
+
+      # unredact it back
+      described_class.new(app_a).process!
+
+      # sanity check it has been unredacted
+      expect(
+        app_a.submitted_application.dig('client_details', 'applicant')
+      ).to match(
+        a_hash_including({ 'nino' => 'AJ123456C' })
+      )
+
+      # sanity check these are indeed the original details
+      expect(
+        app_a.submitted_application.dig('client_details', 'applicant')
+      ).to eq(
+        app_b.submitted_application.dig('client_details', 'applicant')
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
NOTE: this is not fully functional but to the best of my efforts it will not break anything existing on the datastore. Current applications will stay unredacted, and only new submissions will be redacted.

However the `first_name` and `last_name` redacting is temporarily disabled because the `searchable_text` depends on these. The idea is to move this attribute and also `applicant_first_name` and `applicant_last_name`) to the new table `personally_identifiable_details` so they keep working.

Also, some work is needed to avoid (if at all possible, due to certain limitations) N+1 queries. This will be something for a follow-up PR but first we need to solve the `searchable_text` issue.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-402

## Notes for reviewer / how to test
