### PR TITLE
CRIMAP-402 Redacting PII details v2

### DIFF
--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,0 +1,14 @@
+module Redactable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :redacted_crime_application, dependent: :destroy
+
+    before_create :store_redacted_payload, if: :submitted_application
+  end
+
+  def store_redacted_payload
+    Rails.logger.debug { "==> Redacting application ID #{to_param}" }
+    Redacting::Redact.new(self).process!
+  end
+end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -2,12 +2,12 @@ module Redactable
   extend ActiveSupport::Concern
 
   included do
-    has_one :redacted_crime_application, dependent: :destroy
+    has_one :redacted_crime_application, dependent: :destroy, autosave: true
 
-    before_create :store_redacted_payload, if: :submitted_application
+    before_save :perform_redacting, if: :submitted_application
   end
 
-  def store_redacted_payload
+  def perform_redacting
     Rails.logger.debug { "==> Redacting application ID #{to_param}" }
     Redacting::Redact.new(self).process!
   end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,4 +1,6 @@
 class CrimeApplication < ApplicationRecord
+  include Redactable
+
   has_one :return_details, dependent: :destroy
 
   attr_readonly :submitted_application, :submitted_at, :id

--- a/app/models/redacted_crime_application.rb
+++ b/app/models/redacted_crime_application.rb
@@ -1,5 +1,5 @@
 class RedactedCrimeApplication < ApplicationRecord
   belongs_to :crime_application
 
-  attr_readonly :id, :submitted_application
+  attr_readonly :id, :status, :submitted_application
 end

--- a/app/models/redacted_crime_application.rb
+++ b/app/models/redacted_crime_application.rb
@@ -1,0 +1,5 @@
+class RedactedCrimeApplication < ApplicationRecord
+  belongs_to :crime_application
+
+  attr_readonly :id, :submitted_application
+end

--- a/app/services/redacting/base_redacting.rb
+++ b/app/services/redacting/base_redacting.rb
@@ -1,0 +1,37 @@
+module Redacting
+  class BaseRedacting
+    include Rules
+
+    def initialize(record)
+      @record = record
+    end
+
+    # :nocov:
+    def process!
+      raise 'implement in subclasses'
+    end
+    # :nocov:
+
+    private
+
+    attr_reader :record
+
+    # Creates a deep nested hash out of an array of keys
+    # ['a', 'b', 'c'] => { 'a' => { 'b' => { 'c' => details } } }
+    def traverse(path, details)
+      path.reverse.inject(details) { |value, key| { key => value } }
+    end
+
+    def original_payload
+      record.submitted_application
+    end
+
+    def redacted_payload
+      redacted_record.submitted_application
+    end
+
+    def redacted_record
+      @redacted_record ||= (record.redacted_crime_application || record.build_redacted_crime_application)
+    end
+  end
+end

--- a/app/services/redacting/redact.rb
+++ b/app/services/redacting/redact.rb
@@ -20,7 +20,7 @@ module Redacting
       )
 
       # Then we redact from this copy anything according to the rules
-      Rules.all.each do |path, rules|
+      Rules.pii_attributes.each do |path, rules|
         path = path.split('.')
         details = redacted_payload.dig(*path)
 
@@ -48,11 +48,7 @@ module Redacting
     def process_metadata!
       redacted_record.metadata.merge!(
         record.slice(
-          :status,
-          :returned_at,
-          :reviewed_at,
-          :review_status,
-          :offence_class,
+          Rules.metadata_attributes
         )
       )
 

--- a/app/services/redacting/redact.rb
+++ b/app/services/redacting/redact.rb
@@ -9,6 +9,11 @@ module Redacting
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def process!
+      process_metadata!
+
+      # The redacting of the payload is only needed once, on creation
+      return true if redacted_record.persisted?
+
       # First we create an exact copy of the original payload
       redacted_payload.merge!(
         original_payload.dup
@@ -39,6 +44,20 @@ module Redacting
       true
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def process_metadata!
+      redacted_record.metadata.merge!(
+        record.slice(
+          :status,
+          :returned_at,
+          :reviewed_at,
+          :review_status,
+          :offence_class,
+        )
+      )
+
+      true
+    end
 
     private
 

--- a/app/services/redacting/redact.rb
+++ b/app/services/redacting/redact.rb
@@ -1,0 +1,66 @@
+module Redacting
+  class Redact < BaseRedacting
+    def initialize(record)
+      raise ArgumentError, "expected `CrimeApplication` instance, got `#{record.class}`" unless
+        record.is_a?(CrimeApplication)
+
+      super(record)
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def process!
+      # First we create an exact copy of the original payload
+      redacted_payload.merge!(
+        original_payload.dup
+      )
+
+      # Then we redact from this copy anything according to the rules
+      Rules.all.each do |path, rules|
+        path = path.split('.')
+        details = redacted_payload.dig(*path)
+
+        next if details.blank?
+
+        fields = rules.fetch(:redact)
+        type   = rules.fetch(:type, :object)
+
+        details = case type
+                  when :object
+                    details.slice(*fields).compact_blank
+                  when :array
+                    details.map { |item| item.slice(*fields).compact_blank }
+                  else
+                    raise "unknown rule path type: #{type}"
+                  end
+
+        merge_redacted(path, details)
+      end
+
+      true
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    private
+
+    def merge_redacted(path, details)
+      redacted_payload.deep_merge!(
+        traverse(path, redact(details.dup))
+      ) do |_key, original, redacted|
+        if original.is_a?(Array)
+          # Handle collection of hashes, for example `codefendants`
+          original.map.with_index { |item, index| item.deep_merge(redacted[index]) }
+        else
+          redacted
+        end
+      end
+    end
+
+    def redact(details)
+      if details.is_a?(Array)
+        details.map { |item| redact(item.dup) }
+      else
+        details.each_key { |key| details[key] = REDACTED_KEYWORD }
+      end
+    end
+  end
+end

--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -1,0 +1,28 @@
+module Redacting
+  module Rules
+    PII_ATTRIBUTES = {
+      'provider_details' => {
+        redact: %w[legal_rep_first_name legal_rep_last_name legal_rep_telephone]
+      },
+      'client_details.applicant' => {
+        redact: %w[first_name last_name other_names nino telephone_number]
+      },
+      'client_details.applicant.home_address' => {
+        redact: %w[lookup_id address_line_one address_line_two]
+      },
+      'client_details.applicant.correspondence_address' => {
+        redact: %w[lookup_id address_line_one address_line_two]
+      },
+      'case_details.codefendants' => {
+        redact: %w[first_name last_name],
+        type: :array # [{}, {}, ...]
+      },
+    }.freeze
+
+    REDACTED_KEYWORD = '__redacted__'.freeze
+
+    def self.all
+      PII_ATTRIBUTES
+    end
+  end
+end

--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -1,5 +1,7 @@
 module Redacting
   module Rules
+    REDACTED_KEYWORD = '__redacted__'.freeze
+
     PII_ATTRIBUTES = {
       'provider_details' => {
         redact: %w[legal_rep_first_name legal_rep_last_name legal_rep_telephone]
@@ -19,10 +21,22 @@ module Redacting
       },
     }.freeze
 
-    REDACTED_KEYWORD = '__redacted__'.freeze
+    # Additional top level attributes to propagate from the
+    # unredacted table to the redacted one
+    METADATA_ATTRIBUTES = [
+      :status,
+      :returned_at,
+      :reviewed_at,
+      :review_status,
+      :offence_class,
+    ].freeze
 
-    def self.all
+    def self.pii_attributes
       PII_ATTRIBUTES
+    end
+
+    def self.metadata_attributes
+      METADATA_ATTRIBUTES
     end
   end
 end

--- a/app/services/redacting/unredact.rb
+++ b/app/services/redacting/unredact.rb
@@ -1,4 +1,8 @@
 module Redacting
+  # NOTE: we are not using this class in the code, however it is kept
+  # to facilitate some test scenarios, as it performs the inverse
+  # operation of the `Redact` class. Refer to `unredact_spec.rb`
+  #
   class Unredact < BaseRedacting
     def initialize(record)
       raise ArgumentError, "expected `RedactedCrimeApplication` instance, got `#{record.class}`" unless

--- a/app/services/redacting/unredact.rb
+++ b/app/services/redacting/unredact.rb
@@ -1,0 +1,36 @@
+module Redacting
+  class Unredact < BaseRedacting
+    def initialize(record)
+      raise ArgumentError, "expected `RedactedCrimeApplication` instance, got `#{record.class}`" unless
+        record.is_a?(RedactedCrimeApplication)
+
+      super(record.crime_application)
+    end
+
+    def process!
+      Rules.all.each_key do |path|
+        path = path.split('.')
+        details = original_payload.dig(*path)
+
+        unredact(path, details) if details.present?
+      end
+
+      true
+    end
+
+    private
+
+    def unredact(path, details)
+      redacted_payload.deep_merge!(
+        traverse(path, details)
+      ) do |_key, redacted, original|
+        if redacted.is_a?(Array)
+          # Handle collection of hashes, for example `codefendants`
+          redacted.map.with_index { |item, index| item.deep_merge(original[index]) }
+        else
+          original
+        end
+      end
+    end
+  end
+end

--- a/app/services/redacting/unredact.rb
+++ b/app/services/redacting/unredact.rb
@@ -8,7 +8,7 @@ module Redacting
     end
 
     def process!
-      Rules.all.each_key do |path|
+      Rules.pii_attributes.each_key do |path|
         path = path.split('.')
         details = original_payload.dig(*path)
 

--- a/db/migrate/20230606112337_create_redacted_crime_applications.rb
+++ b/db/migrate/20230606112337_create_redacted_crime_applications.rb
@@ -1,0 +1,8 @@
+class CreateRedactedCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :redacted_crime_applications, id: :uuid do |t|
+      t.references :crime_application, type: :uuid, foreign_key: true, null: true, index: { unique: true }
+      t.jsonb :submitted_application, null: false, default: {}
+    end
+  end
+end

--- a/db/migrate/20230609142410_add_metadata_to_redacted_table.rb
+++ b/db/migrate/20230609142410_add_metadata_to_redacted_table.rb
@@ -1,0 +1,12 @@
+class AddMetadataToRedactedTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column :redacted_crime_applications, :metadata, :jsonb, null: false, default: {}
+
+    add_column(
+      :redacted_crime_applications, :status, :virtual,
+      as: "(metadata->>'status')", type: :string, stored: true
+    )
+
+    add_index :redacted_crime_applications, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_06_112337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -39,6 +39,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
   end
 
+  create_table "redacted_crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "crime_application_id"
+    t.jsonb "submitted_application", default: {}, null: false
+    t.index ["crime_application_id"], name: "index_redacted_crime_applications_on_crime_application_id", unique: true
+  end
+
   create_table "return_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "reason", null: false
     t.text "details"
@@ -48,5 +54,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_102128) do
     t.index ["crime_application_id"], name: "index_return_details_on_crime_application_id"
   end
 
+  add_foreign_key "redacted_crime_applications", "crime_applications"
   add_foreign_key "return_details", "crime_applications"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_06_112337) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_09_142410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -42,7 +42,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_06_112337) do
   create_table "redacted_crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "crime_application_id"
     t.jsonb "submitted_application", default: {}, null: false
+    t.jsonb "metadata", default: {}, null: false
+    t.virtual "status", type: :string, as: "(metadata ->> 'status'::text)", stored: true
     t.index ["crime_application_id"], name: "index_redacted_crime_applications_on_crime_application_id", unique: true
+    t.index ["status"], name: "index_redacted_crime_applications_on_status"
   end
 
   create_table "return_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/crime_application_spec.rb
+++ b/spec/models/crime_application_spec.rb
@@ -18,6 +18,10 @@ describe CrimeApplication do
       expect { create }.to change(described_class, :count).by 1
     end
 
+    it 'persists the redacted application' do
+      expect { create }.to change(RedactedCrimeApplication, :count).by 1
+    end
+
     context 'when a record with the id already exists' do
       before do
         described_class.create!(id: application_attributes['id'])
@@ -41,6 +45,14 @@ describe CrimeApplication do
         expect(
           application.submitted_at
         ).to eq(application_attributes['submitted_at'])
+      end
+
+      describe 'redacted application' do
+        let(:redacted_application) { application.redacted_crime_application }
+
+        it 'has a the same status attribute' do
+          expect(application.status).to eq(redacted_application.status)
+        end
       end
 
       describe 'Setting the offence class' do
@@ -70,6 +82,33 @@ describe CrimeApplication do
             ).to eq 'C'
           end
         end
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:application) { described_class.find(application_attributes['id']) }
+
+    before do
+      described_class.create!(valid_attributes)
+    end
+
+    let(:redacted_application) { application.redacted_crime_application }
+
+    context 'when updating the status of the application' do
+      it 'updates the status' do
+        expect do
+          application.update!(status: 'returned')
+        end.to change(application, :status).from('submitted').to('returned')
+      end
+
+      it 'updates the redacted application status' do
+        expect(redacted_application.status).to eq('submitted')
+
+        application.update!(status: 'returned')
+        redacted_application.reload
+
+        expect(redacted_application.status).to eq('returned')
       end
     end
   end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+describe Redacting::Redact do
+  subject { described_class.new(crime_application) }
+
+  let(:crime_application) { CrimeApplication.new(submitted_application:) }
+  let(:submitted_application) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+
+  let(:redacted_application) { crime_application.redacted_crime_application.submitted_application }
+
+  # rubocop:disable Layout/FirstHashElementIndentation, RSpec/ExampleLength
+  describe 'redacting of a submitted application' do
+    before do
+      subject.process!
+    end
+
+    context 'with provider details' do
+      let(:provider_details) { redacted_application['provider_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(provider_details).to eq({
+          'office_code' => '1A123B',
+          'provider_email' => 'provider@example.com',
+          'legal_rep_first_name' => '__redacted__',
+          'legal_rep_last_name' => '__redacted__',
+          'legal_rep_telephone' => '__redacted__',
+        })
+      end
+    end
+
+    context 'with client details' do
+      let(:client_details) { redacted_application['client_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(client_details['applicant']).to eq({
+          'first_name' => '__redacted__',
+          'last_name' => '__redacted__',
+          'nino' => '__redacted__',
+          'date_of_birth' => '2001-06-09',
+          'telephone_number' => '__redacted__',
+          'correspondence_address_type' => 'home_address',
+          'home_address' => {
+            'lookup_id' => nil,
+            'address_line_one' => '__redacted__',
+            'address_line_two' => '__redacted__',
+            'city' => 'Some nice city',
+            'country' => 'United Kingdom',
+            'postcode' => 'SW1A 2AA',
+          },
+          'correspondence_address' => nil
+        })
+      end
+    end
+
+    context 'with case details' do
+      let(:case_details) { redacted_application['case_details'] }
+
+      it 'redacts the expected attributes' do
+        expect(case_details['codefendants']).to eq(
+          [{
+            'first_name' => '__redacted__',
+            'last_name' => '__redacted__',
+            'conflict_of_interest' => 'yes'
+          }]
+        )
+      end
+    end
+  end
+
+  describe 'for blank or null attributes' do
+    let(:submitted_application) do
+      LaaCrimeSchemas.fixture(1.0) do |json|
+        json.deep_merge(
+          'client_details' => { 'applicant' => { 'other_names' => '', 'nino' => nil } }
+        )
+      end
+    end
+
+    it 'does not redact them, keep the original value' do
+      subject.process!
+
+      expect(redacted_application['client_details']['applicant']).to match(
+        a_hash_including({
+          'other_names' => '',
+          'nino' => nil,
+          'telephone_number' => '__redacted__',
+        })
+      )
+    end
+  end
+  # rubocop:enable Layout/FirstHashElementIndentation, RSpec/ExampleLength
+
+  describe 'invalid rules' do
+    before do
+      allow(Redacting::Rules).to receive(:all).and_return(rules)
+    end
+
+    context 'when `redact` information is not found' do
+      let(:rules) do
+        { 'provider_details' => {} }
+      end
+
+      it 'raises a key not found error' do
+        expect { subject.process! }.to raise_error(KeyError, /key not found: :redact/)
+      end
+    end
+
+    context 'when the `type` is unrecognised' do
+      let(:rules) do
+        { 'provider_details' => { redact: %w[], type: :date } }
+      end
+
+      it 'raises a key not found error' do
+        expect { subject.process! }.to raise_error(RuntimeError, /unknown rule path type: date/)
+      end
+    end
+  end
+end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -67,6 +67,24 @@ describe Redacting::Redact do
     end
   end
 
+  describe 'metadata attributes' do
+    let(:metadata) { crime_application.redacted_crime_application.metadata }
+
+    before do
+      subject.process!
+    end
+
+    it 'contains the expected metadata json' do
+      expect(metadata).to eq({
+        'status' => 'submitted',
+        'reviewed_at' => nil,
+        'returned_at' => nil,
+        'review_status' => 'application_received',
+        'offence_class' => nil,
+      })
+    end
+  end
+
   describe 'for blank or null attributes' do
     let(:submitted_application) do
       LaaCrimeSchemas.fixture(1.0) do |json|
@@ -92,7 +110,7 @@ describe Redacting::Redact do
 
   describe 'invalid rules' do
     before do
-      allow(Redacting::Rules).to receive(:all).and_return(rules)
+      allow(Redacting::Rules).to receive(:pii_attributes).and_return(rules)
     end
 
     context 'when `redact` information is not found' do

--- a/spec/services/redacting/rules_spec.rb
+++ b/spec/services/redacting/rules_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Redacting::Rules do
+  describe '.pii_attributes' do
+    # Sanity check only, more thorough tests part of `redact_spec.rb`
+    it 'has the expected paths' do
+      expect(
+        described_class.pii_attributes.keys
+      ).to match_array(
+        %w[
+          provider_details
+          client_details.applicant
+          client_details.applicant.correspondence_address
+          client_details.applicant.home_address
+          case_details.codefendants
+        ]
+      )
+    end
+  end
+
+  describe '.metadata_attributes' do
+    it 'has the expected attributes' do
+      expect(
+        described_class.metadata_attributes
+      ).to contain_exactly(
+        :status,
+        :returned_at,
+        :reviewed_at,
+        :review_status,
+        :offence_class,
+      )
+    end
+  end
+end

--- a/spec/services/redacting/unredact_spec.rb
+++ b/spec/services/redacting/unredact_spec.rb
@@ -32,11 +32,11 @@ describe Redacting::Unredact do
         a_hash_including({ 'nino' => 'AJ123456C' })
       )
 
-      # sanity check these are indeed the original details
+      # sanity check the payloads are identical after the unredact
       expect(
-        crime_application.submitted_application.dig('client_details', 'applicant')
+        crime_application.submitted_application
       ).to eq(
-        redacted_application.submitted_application.dig('client_details', 'applicant')
+        redacted_application.submitted_application
       )
     end
   end

--- a/spec/services/redacting/unredact_spec.rb
+++ b/spec/services/redacting/unredact_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe Redacting::Unredact do
+  let(:submitted_application) { JSON.parse(LaaCrimeSchemas.fixture(1.0).read) }
+
+  let(:crime_application) { CrimeApplication.new(submitted_application:) }
+  let(:redacted_application) { crime_application.redacted_crime_application }
+
+  # rubocop:disable RSpec/ExampleLength
+  describe 'unredacting of a submitted application' do
+    it 'matches the original application' do
+      # redact the application
+      Redacting::Redact.new(crime_application).process!
+
+      # sanity check it has been redacted in the redacted instance
+      expect(
+        redacted_application.submitted_application.dig('client_details', 'applicant')
+      ).to match(a_hash_including({ 'nino' => '__redacted__' }))
+
+      # sanity check it has not been changed in the original instance
+      expect(
+        crime_application.submitted_application.dig('client_details', 'applicant')
+      ).to match(a_hash_including({ 'nino' => 'AJ123456C' }))
+
+      # unredact it back
+      described_class.new(redacted_application).process!
+
+      # sanity check it has been unredacted
+      expect(
+        redacted_application.submitted_application.dig('client_details', 'applicant')
+      ).to match(
+        a_hash_including({ 'nino' => 'AJ123456C' })
+      )
+
+      # sanity check these are indeed the original details
+      expect(
+        crime_application.submitted_application.dig('client_details', 'applicant')
+      ).to eq(
+        redacted_application.submitted_application.dig('client_details', 'applicant')
+      )
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+end


### PR DESCRIPTION
## Description of change
Please for full context refer to existing open PR #106 as this is an iteration over that one.

This approach is quite similar (in fact I've been able to reuse almost all code with minor to no changes) with the difference the redacted payload (in its entirety, not just the redacted attributes) is stored in a separate table named `redacted_crime_applications`.

The original, unredacted payload, thus reside untouched in the original table `crime_applications`.

The advantage is, as we have it already unredacted, there is no join or any operation on reading back these applications (thus we eliminate N+1 issues). The redacted table can then be used purely for analytics like metabase, by granting access to this table (instead of the "unredacted" one).

Also, no need to make changes to the `searchable_text` and other virtual attributes as these remain in the main, unredacted table like before.

The only disadvantage might be slightly more work to do for "right to forget", and possibly Metabase might lose access to some top level `crime_applications` table attributes (`returned_at`, `reviewed_at`, `offence_class`...) unless these can be obtained from the payload (some aren't).

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-402

## Notes for reviewer / how to test
