### PR TITLE
Grant permission to metabase user to redacted table

### DIFF
--- a/config/kubernetes/staging/psql_job.yml
+++ b/config/kubernetes/staging/psql_job.yml
@@ -27,7 +27,7 @@ spec:
             psql -d ${DATABASE_URL} -c "ALTER ROLE ${READONLY_USER} WITH PASSWORD '${READONLY_PASSWORD}'";
             psql -d ${DATABASE_URL} -e -c "GRANT CONNECT ON DATABASE ${DATABASE_NAME} TO ${READONLY_USER}";
             psql -d ${DATABASE_URL} -e -c "GRANT USAGE ON SCHEMA public TO ${READONLY_USER}";
-            psql -d ${DATABASE_URL} -e -c "GRANT SELECT ON crime_applications TO ${READONLY_USER}";
+            psql -d ${DATABASE_URL} -e -c "GRANT SELECT ON redacted_crime_applications TO ${READONLY_USER}";
             psql -d ${DATABASE_URL} -e -c "GRANT SELECT ON return_details TO ${READONLY_USER}";
         env:
         # secrets created by terraform


### PR DESCRIPTION
## Description of change
Follow-up to PR #107.

I've manually dropped the old user and roles so that `metabase` user only has access to the new `redacted_crime_applications` (and `return_details` as before).

We will need to update metabase queries too.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-402

## Notes for reviewer / how to test
