### PR TITLE
Store return reason in the redacted metadata

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -10,6 +10,9 @@ class CrimeApplication < ApplicationRecord
   before_validation :shift_payload_attributes, on: :create
   before_validation :set_overall_offence_class, on: :create
 
+  # Exposes a `return_reason` method, used in the redacted metadata
+  delegate :reason, to: :return_details, prefix: :return, allow_nil: true
+
   private
 
   def shift_payload_attributes

--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -33,6 +33,8 @@ module Redacting
       :reviewed_at,
       :review_status,
       :offence_class,
+      # delegated attributes below
+      :return_reason,
     ].freeze
 
     def self.pii_attributes

--- a/config/kubernetes/staging/psql_job.yml
+++ b/config/kubernetes/staging/psql_job.yml
@@ -28,7 +28,6 @@ spec:
             psql -d ${DATABASE_URL} -e -c "GRANT CONNECT ON DATABASE ${DATABASE_NAME} TO ${READONLY_USER}";
             psql -d ${DATABASE_URL} -e -c "GRANT USAGE ON SCHEMA public TO ${READONLY_USER}";
             psql -d ${DATABASE_URL} -e -c "GRANT SELECT ON redacted_crime_applications TO ${READONLY_USER}";
-            psql -d ${DATABASE_URL} -e -c "GRANT SELECT ON return_details TO ${READONLY_USER}";
         env:
         # secrets created by terraform
         - name: DATABASE_URL

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -71,6 +71,30 @@ describe Operations::ReturnApplication do
         ).to have_received(:publish)
       end
 
+      context 'with redacted application metadata' do
+        before do
+          call
+        end
+
+        let(:return_details) { { reason: Types::ReturnReason['clarification_required'], details: 'Some details' } }
+        let(:redacted_metadata) { application.reload.redacted_crime_application.metadata }
+
+        it 'updates the metadata' do
+          expect(
+            redacted_metadata
+          ).to eq(
+            {
+              'offence_class' => nil,
+              'return_reason' => 'clarification_required',
+              'returned_at' => application.returned_at.to_time.utc.iso8601(3),
+              'reviewed_at' => application.reviewed_at.to_time.utc.iso8601(3),
+              'review_status' => 'returned_to_provider',
+              'status' => 'returned',
+            }
+          )
+        end
+      end
+
       context 'when application has already been returned' do
         before { application.update(status: :returned, returned_at: 1.day.ago) }
 

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -94,6 +94,7 @@ describe Redacting::Redact do
         'returned_at' => nil,
         'review_status' => 'application_received',
         'offence_class' => nil,
+        'return_reason' => nil,
       })
     end
   end

--- a/spec/services/redacting/rules_spec.rb
+++ b/spec/services/redacting/rules_spec.rb
@@ -29,6 +29,7 @@ describe Redacting::Rules do
         :reviewed_at,
         :review_status,
         :offence_class,
+        :return_reason,
       )
     end
   end


### PR DESCRIPTION
## Description of change
The only bit of information that we need to perform analytics is the return reason. We don't need the free text `details`, and also this may contain PII.

As this is a separate table (`return_details`) we gave access to metabase, but we can remove access with this change.

Another alternative solution would be to refactor the `return_details` table so their attributes are part of the main `crime_application` table (maybe a jsonb or just first level attrs) and remove the table as no longer needed. It holds very little information as it is now. But this involves more work and thinking as it is used in the entities, etc.

## Link to relevant ticket

## Notes for reviewer / how to test
More context on slack:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1686748396925349