### PR TITLE
Keep metabase replicas to just one

### DIFF
--- a/config/kubernetes/metabase/deployment.yml
+++ b/config/kubernetes/metabase/deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: deployment
   namespace: laa-criminal-applications-metabase
 spec:
-  replicas: 2
+  replicas: 1 # NOTE: should remain 1
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
## Description of change
It seems metabase doesn't play nice whith more than 1 replica. Perhaps requires further investigation but for now is safe to keep it to just 1.
