### PR TITLE
Set metabase modsec allowed verbs

### DIFF
--- a/config/kubernetes/metabase/ingress.yml
+++ b/config/kubernetes/metabase/ingress.yml
@@ -20,7 +20,7 @@ metadata:
       SecRuleEngine On
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
-      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change
For some reason modsec was blocking PUT requests. I've also added DELETE as it is probably needed. Basically we want to allow all verb methods as all are required.

Interestingly on Apply/Review this is not an issue (so far) but again we have to keep an eye on modsec logs.

