### PR TITLE
Bump schemas gem to v0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.4.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.5.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 39186b9ebf3d71c00e3b53b506c936aed52429ef
-  tag: v0.4.0
+  revision: 86ed15ee153a473c77e9683e3f0e51895d9e935f
+  tag: v0.5.0
   specs:
-    laa-criminal-legal-aid-schemas (0.4.0)
+    laa-criminal-legal-aid-schemas (0.5.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 


### PR DESCRIPTION
## Description of change
Needed because the name of a mandatory attribute on the submission schema has changed.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-415

## Notes for reviewer / how to test
