### PR TITLE
Ignore trivy vulns outside our control

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# CVEs that are outside of our control
+#
+CVE-2023-2253
+CVE-2023-28840
+CVE-2023-30551


### PR DESCRIPTION
## Description of change
These keep coming back in prometheus alerts and we are unable to fix them as it seems to be on cloud platforms side.

As a test I installed and run Trivy locally (before adding this ignore file that is!) and it didn't detect any vulns so it must have something to do with k8s.

