### PR TITLE
Increase modsec rule 949110 inbound anomaly score threshold

### DIFF
--- a/config/kubernetes/metabase/ingress.yml
+++ b/config/kubernetes/metabase/ingress.yml
@@ -21,6 +21,7 @@ metadata:
       SecRequestBodyLimit 1048576
       SecRequestBodyNoFilesLimit 1048576
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apply,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
+      SecAction "id:949110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=12"
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description of change

When running sql queries in metabase, requests are being blocked by modsec under rule ID 949110 for exceeding the inbound anomaly score threshold. After some investigation, this seems to be related to use of SQL functions in the query (e.g. AVG). It has been decided to raise the threshold to 12 (typically the exceeded threshold value was 10) which should let most of the usual queries work. Also these errors aren't raised with metabase's visual editor so this should be used primarily to construct widgets etc.. 

If from time to time if we want to create more complex queries, we may need to temporarily disable modsec and after queries are created, re-enable it. 

## Link to relevant ticket
[CRIMRE-363](https://dsdmoj.atlassian.net/browse/CRIMRE-363)

## Notes for reviewer / how to test
