### PR TITLE
Add some more params to the filter

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -8,8 +8,10 @@ Rails.application.config.filter_parameters += [
   # Attributes relating to an application
   # It does partial matching (i.e. `case_details` is covered by `details`)
   :application,
+  :date_of_birth,
   :details,
   :first_name,
   :last_name,
+  :search_text,
   :searchable_text,
 ]


### PR DESCRIPTION
## Description of change
These were coming through when performing searches on Review. `date_of_birth` covers `applicant_date_of_birth`.

Added to the filtering list.

## Notes for reviewer / how to test
Observe the logs for a search, it should now be:
```
"params":{"search":{"applicant_date_of_birth":"[FILTERED]","application_id_in":"[FILTERED]","application_id_not_in":"[FILTERED]","review_status":["application_received","ready_for_assessment"],"submitted_after":null,"submitted_before":null,"search_text":"[FILTERED]"}
```