### PR TITLE
CRIMAP-427 Bump schemas gem (appeal_lodged_date)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.5.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 86ed15ee153a473c77e9683e3f0e51895d9e935f
-  tag: v0.5.0
+  revision: bf2bbf156ff4d89c815bea9dba1b3a1f0cbe96c0
+  tag: v0.6.0
   specs:
-    laa-criminal-legal-aid-schemas (0.5.0)
+    laa-criminal-legal-aid-schemas (0.6.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'get application ready for maat' do
         {
           'case_type' => application.submitted_application['case_details']['case_type'],
           'appeal_maat_id' => application.submitted_application['case_details']['appeal_maat_id'],
-          'appeal_with_changes_maat_id' => application.submitted_application['case_details']['appeal_with_changes_maat_id'],
+          'appeal_lodged_date' => application.submitted_application['case_details']['appeal_lodged_date'],
           'appeal_with_changes_details' => application.submitted_application['case_details']['appeal_with_changes_details'],
           'hearing_court_name' => application.submitted_application['case_details']['hearing_court_name'],
           'hearing_date' => application.submitted_application['case_details']['hearing_date'],


### PR DESCRIPTION
## Description of change
Bump the schemas gem, which contains the refactor of the appeal attributes, incorporating the new `appeal_lodged_date`.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-427

## Notes for reviewer / how to test
