### PR TITLE
Return declaration signed date for maat applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.6.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: bf2bbf156ff4d89c815bea9dba1b3a1f0cbe96c0
-  tag: v0.6.0
+  revision: dc0dce7fddf899a920fb419f67a936ead184b34f
+  tag: v0.6.1
   specs:
-    laa-criminal-legal-aid-schemas (0.6.0)
+    laa-criminal-legal-aid-schemas (0.6.1)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,7 +3,7 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
-          expose :signed_at
+          expose :declaration_signed_at
 
           private
 
@@ -11,7 +11,7 @@ module Datastore
             super.except('offences', 'codefendants')
           end
 
-          def signed_at
+          def declaration_signed_at
             submitted_value('submitted_at')
           end
         end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,16 +3,12 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
-          expose :declaration_signed_at
+          expose :submitted_at, as: :declaration_signed_at
 
           private
 
           def case_details
             super.except('offences', 'codefendants')
-          end
-
-          def declaration_signed_at
-            submitted_value('submitted_at')
           end
         end
       end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,10 +3,16 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
+          expose :signed_at
+
           private
 
           def case_details
             super.except('offences', 'codefendants')
+          end
+
+          def signed_at
+            submitted_value('submitted_at')
           end
         end
       end

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'get application ready for maat' do
           'client_details' => application.submitted_application['client_details'],
           'provider_details' => application.submitted_application['provider_details'],
           'submitted_at' => application.submitted_application['submitted_at'],
-          'signed_at' => application.submitted_application['submitted_at'],
+          'declaration_signed_at' => application.submitted_application['submitted_at'],
           'date_stamp' => application.submitted_application['date_stamp'],
           'interests_of_justice' => application.submitted_application['interests_of_justice'],
           'case_details' => expected_case_details,

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe 'get application ready for maat' do
           'client_details' => application.submitted_application['client_details'],
           'provider_details' => application.submitted_application['provider_details'],
           'submitted_at' => application.submitted_application['submitted_at'],
+          'signed_at' => application.submitted_application['submitted_at'],
           'date_stamp' => application.submitted_application['date_stamp'],
           'interests_of_justice' => application.submitted_application['interests_of_justice'],
           'case_details' => expected_case_details,


### PR DESCRIPTION
## Description of change
This PR exposes a `declaration_signed_at` field for MAAT applications for MAAT integration. For the time being, this field returns the `submitted_at` date. It also bumps the schema gem following accompanying schema changes [(#34)](https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/34)

## Link to relevant ticket
[CRIMRE-387](https://dsdmoj.atlassian.net/browse/CRIMRE-387)

## Notes for reviewer / how to test


[CRIMRE-387]: https://dsdmoj.atlassian.net/browse/CRIMRE-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ