### PR TITLE
Better grafana reports for Grape API endpoints

### DIFF
--- a/app/lib/prometheus_metrics/grape_middleware.rb
+++ b/app/lib/prometheus_metrics/grape_middleware.rb
@@ -2,20 +2,44 @@ module PrometheusMetrics
   require 'prometheus_exporter/middleware'
 
   class GrapeMiddleware < PrometheusExporter::Middleware
-    def custom_labels(env)
-      return unless env['api.endpoint']
-
-      api_version = env['api.version'] || 'n/a'
-      api_namespace = env['api.endpoint'].namespace
-      api_method = env['api.endpoint'].options[:method].first
+    def default_labels(env, result)
+      return super unless _api_request?(env)
 
       {
-        api_version:,
-        api_namespace:,
-        api_method:,
+        controller: "(api:#{_api_method(env).downcase})",
+        action: _api_action(env),
+      }
+    rescue StandardError
+      super
+    end
+
+    def custom_labels(env)
+      return unless _api_request?(env)
+
+      {
+        api_version: _api_version(env),
+        api_method: _api_method(env),
       }
     rescue StandardError
       nil
+    end
+
+    private
+
+    def _api_request?(env)
+      env['api.endpoint'].present?
+    end
+
+    def _api_action(env)
+      env['api.endpoint'].namespace
+    end
+
+    def _api_method(env)
+      env['api.endpoint'].options[:method].first
+    end
+
+    def _api_version(env)
+      env['api.version'] || 'n/a'
     end
   end
 end


### PR DESCRIPTION
## Description of change
Currently all API endpoints have controller "other" and action "other", and most of the grafana dashboards work with these controller/action.

To make it more meaningful, the same we had custom labels, we now have default labels for grape API endpoints, where the controller is `(api:method)` (method being get, post, put, etc.) and the action is whatever the endpoint was. This allows for better metrics when using unified Grafana dashboards like golden signals.

Example:
```
ruby_http_requests_total{controller="(api:get)",action="/applications",api_version="v1",api_method="GET",status="200"} 4
ruby_http_requests_total{controller="(api:get)",action="/applications/:application_id",api_version="v1",api_method="GET",status="200"} 1
ruby_http_requests_total{action="ping",controller="status",status="200"} 1
```