### PR TITLE
CRIMAP-436 Expose `ioj_bypass` in MAAT json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.7.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.8.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5dae17e1af44335493dae6932b9257e8a9ba6b08
-  tag: v0.7.0
+  revision: b5fb3232c9e1dd965e018b27ca7d5d35a439394b
+  tag: v0.8.0
   specs:
-    laa-criminal-legal-aid-schemas (0.7.0)
+    laa-criminal-legal-aid-schemas (0.8.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,7 +3,10 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
+          unexpose :interests_of_justice
+
           expose :submitted_at, as: :declaration_signed_at
+          expose :ioj_bypass, proc: ->(_) { interests_of_justice.empty? }
 
           private
 

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'get application ready for maat' do
           'submitted_at' => application.submitted_application['submitted_at'],
           'declaration_signed_at' => application.submitted_application['submitted_at'],
           'date_stamp' => application.submitted_application['date_stamp'],
-          'interests_of_justice' => application.submitted_application['interests_of_justice'],
+          'ioj_bypass' => application.submitted_application['interests_of_justice'].empty?,
           'case_details' => expected_case_details,
           'schema_version' => application.submitted_application['schema_version'],
           'id' => application.id


### PR DESCRIPTION
## Description of change
Necessary changes to go along with the new schemas gem version.

As discussed, the `interests_of_justice` attribute is no longer returned in the MAAT json, and is replaced with a new `ioj_bypass` boolean, whether we captured interests of justice reasons from the provider, or not.

It simplifies business logic for MAAT injection.

Apply / Review services are not affected by this changes and there is no need to bump the schemas gem just for this.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-436

## Notes for reviewer / how to test
