### PR TITLE
CRIMAP-450 Expose `means_passport` in MAAT json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'moj-simple-jwt-auth', '0.1.0'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.8.0'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v0.9.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: b5fb3232c9e1dd965e018b27ca7d5d35a439394b
-  tag: v0.8.0
+  revision: f2dd23fde2eec68b1aa097dbcb36cea6b48ae7bd
+  tag: v0.9.0
   specs:
-    laa-criminal-legal-aid-schemas (0.8.0)
+    laa-criminal-legal-aid-schemas (0.9.0)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 

--- a/app/api/datastore/entities/v1/base_application_entity.rb
+++ b/app/api/datastore/entities/v1/base_application_entity.rb
@@ -8,6 +8,10 @@ module Datastore
         expose :application_type
         expose :submitted_at
         expose :date_stamp
+
+        expose :ioj_passport
+        expose :means_passport
+
         expose :provider_details
         expose :client_details
         expose :case_details
@@ -34,6 +38,14 @@ module Datastore
 
         def date_stamp
           submitted_value('date_stamp')
+        end
+
+        def ioj_passport
+          submitted_value('ioj_passport')
+        end
+
+        def means_passport
+          submitted_value('means_passport')
         end
 
         def provider_details

--- a/app/api/datastore/entities/v1/crime_application.rb
+++ b/app/api/datastore/entities/v1/crime_application.rb
@@ -5,8 +5,6 @@ module Datastore
         expose :status
         expose :parent_id
         expose :created_at
-        expose :ioj_passport
-        expose :means_passport
 
         expose :returned_at, expose_nil: false
         expose :return_details, expose_nil: false
@@ -21,14 +19,6 @@ module Datastore
         # and therefore we take the value from the application json rather than the table
         def created_at
           submitted_value('created_at')
-        end
-
-        def ioj_passport
-          submitted_value('ioj_passport')
-        end
-
-        def means_passport
-          submitted_value('means_passport')
         end
       end
     end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,7 +3,8 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
-          unexpose :interests_of_justice
+          unexpose :ioj_passport,
+                   :interests_of_justice
 
           expose :submitted_at, as: :declaration_signed_at
           expose :ioj_bypass, proc: ->(_) { interests_of_justice.empty? }

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'get application ready for maat' do
           'submitted_at' => application.submitted_application['submitted_at'],
           'declaration_signed_at' => application.submitted_application['submitted_at'],
           'date_stamp' => application.submitted_application['date_stamp'],
+          'means_passport' => application.submitted_application['means_passport'],
           'ioj_bypass' => application.submitted_application['interests_of_justice'].empty?,
           'case_details' => expected_case_details,
           'schema_version' => application.submitted_application['schema_version'],


### PR DESCRIPTION
## Description of change
Counterpart change to go along with change in schemas gem. https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/38

Shifted the `ioj_passport` and `means_passport` attributes to the base entity for clarity but we unexpose  `ioj_passport` in the maat entity.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-450

## Notes for reviewer / how to test
