### PR TITLE
Deauthorise return endpoint to `apply` consumer

### DIFF
--- a/app/api/datastore/v1/reviewing.rb
+++ b/app/api/datastore/v1/reviewing.rb
@@ -18,7 +18,7 @@ module Datastore
             route_setting :authorised_consumers, (
               %w[crime-review].tap do |consumers|
                 # In non-prod envs, we also let `crime-apply` issue returns (developer tools)
-                consumers.append('crime-apply') unless HostEnv.production?
+                consumers.append('crime-apply') unless Rails.env.production?
               end
             )
             put do


### PR DESCRIPTION
## Description of change
Follow-up to previous PR #130.

Further deauthorise `crime-apply` from using the `return` endpoint, in any production environment (this includes any deployed cloud environment, like staging or production).

Only non-prod envs like localhost will be allowed.

More details:
https://mojdt.slack.com/archives/C03JS4V9TPU/p1689342616165039

## Link to relevant ticket

## Notes for reviewer / how to test
On staging, trying to return an application from the developer tools, will no longer work.
NOTE: the button will also be removed from Apply in a separate PR later on.