### PR TITLE
CRIMAP-464 Unredact legal rep name attributes

### DIFF
--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -4,7 +4,7 @@ module Redacting
 
     PII_ATTRIBUTES = {
       'provider_details' => {
-        redact: %w[legal_rep_first_name legal_rep_last_name legal_rep_telephone]
+        redact: %w[legal_rep_telephone]
       },
       'client_details.applicant' => {
         redact: %w[first_name last_name other_names nino telephone_number]

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -21,8 +21,8 @@ describe Redacting::Redact do
         expect(provider_details).to eq({
           'office_code' => '1A123B',
           'provider_email' => 'provider@example.com',
-          'legal_rep_first_name' => '__redacted__',
-          'legal_rep_last_name' => '__redacted__',
+          'legal_rep_first_name' => 'John',
+          'legal_rep_last_name' => 'Doe',
           'legal_rep_telephone' => '__redacted__',
         })
       end


### PR DESCRIPTION
## Description of change
This is part of a wider investigation Chris Purvis is performing.

So far these 2 need to be unredacted as will be used for reporting purposes. This is information that is required by contract managers.

Clarification on `postcode` is required, but the person in charge of that is on holidays until Monday.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-464

## Notes for reviewer / how to test
