### PR TITLE
CRIMAP-525 Implement delete document endpoint

### DIFF
--- a/app/api/datastore/v1/documents.rb
+++ b/app/api/datastore/v1/documents.rb
@@ -27,6 +27,19 @@ module Datastore
             :get, **declared(params).symbolize_keys
           ).call
         end
+
+        desc 'Delete a document.'
+        route_setting :authorised_consumers, %w[crime-apply]
+        params do
+          requires :object_key, type: String, desc: 'S3 object key to delete, Base64 encoded.'
+        end
+        route_param :object_key do
+          delete do
+            Operations::Documents::Delete.new(
+              object_key: params[:object_key]
+            ).call
+          end
+        end
       end
     end
   end

--- a/app/services/operations/documents/delete.rb
+++ b/app/services/operations/documents/delete.rb
@@ -1,0 +1,25 @@
+module Operations
+  module Documents
+    class Delete
+      include Traits::S3Operation
+
+      attr_accessor :object_key
+
+      def initialize(object_key:)
+        @object_key = Base64.strict_decode64(object_key)
+      end
+
+      def call
+        object.delete
+
+        {
+          object_key:
+        }
+      rescue StandardError => e
+        raise Errors::DocumentUploadError, e
+      ensure
+        log(object_key:)
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v1/documents/delete_spec.rb
+++ b/spec/api/datastore/v1/documents/delete_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'delete a document' do
+  let(:operation_class) { Operations::Documents::Delete }
+  let(:stubbed_operation) { instance_double(operation_class, call: {}) }
+
+  let(:object_key) { 'MTIzL3h5ei9mb29iYXI=' }
+
+  before do
+    allow(
+      operation_class
+    ).to receive(:new).with(object_key:).and_return(stubbed_operation)
+  end
+
+  describe 'DELETE /documents/:object_key' do
+    subject(:api_request) do
+      delete "/api/v1/documents/#{object_key}"
+    end
+
+    it_behaves_like 'a documents API endpoint'
+
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply] do
+      before { api_request }
+    end
+  end
+end

--- a/spec/services/operations/documents/delete_spec.rb
+++ b/spec/services/operations/documents/delete_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Operations::Documents::Delete do
+  subject { described_class.new(object_key:) }
+
+  let(:object_key) { 'MTIzL2ZpbGVuYW1l' }
+  let(:decoded_object_key) { '123/filename' }
+
+  describe '.new' do
+    it 'decodes the object_key' do
+      expect(subject.object_key).to eq(decoded_object_key)
+    end
+  end
+
+  describe '#call' do
+    include_context 'with an S3 client'
+
+    let(:endpoint) { 'https://s3.eu-west-2.amazonaws.com/s3_bucket_name/123/filename' }
+
+    context 'when there is no error' do
+      before do
+        stub_request(:delete, endpoint)
+          .to_return(status: 200, body: '', headers: {})
+      end
+
+      it 'performs the deletion of the object and logs the operation' do
+        expect(subject.call).to eq({ object_key: decoded_object_key })
+
+        expect(logger).to have_received(:info).with(
+          [
+            '[Operations::Documents::Delete]',
+            { object_key: decoded_object_key }.to_json
+          ].join(' ')
+        )
+      end
+    end
+
+    context 'when there is an error' do
+      before do
+        stub_request(:delete, endpoint)
+          .to_raise(StandardError.new('boom!'))
+      end
+
+      it 'logs the operation and re-raises the exception' do
+        expect { subject.call }.to raise_error(Errors::DocumentUploadError)
+
+        expect(logger).to have_received(:error).with(
+          [
+            '[Operations::Documents::Delete]',
+            { object_key: decoded_object_key, error: 'boom!' }.to_json
+          ].join(' ')
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Following up with remaining document operations.

I will raise a counterpart PR on the datastore API gem to be able to call this new endpoint.

I've shared on slack a document on how to test these PRs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-525

## Notes for reviewer / how to test
