### PR TITLE
CRIMAP-525 Implement list documents endpoint

### DIFF
--- a/app/api/datastore/v1/documents.rb
+++ b/app/api/datastore/v1/documents.rb
@@ -28,6 +28,19 @@ module Datastore
           ).call
         end
 
+        desc 'List all documents for an application USN.'
+        route_setting :authorised_consumers, %w[crime-apply crime-review]
+        params do
+          requires :usn, type: Integer, desc: 'Application USN.'
+        end
+        route_param :usn do
+          get do
+            Operations::Documents::List.new(
+              **declared(params).symbolize_keys
+            ).call
+          end
+        end
+
         desc 'Delete a document.'
         route_setting :authorised_consumers, %w[crime-apply]
         params do

--- a/app/services/operations/documents/list.rb
+++ b/app/services/operations/documents/list.rb
@@ -1,0 +1,27 @@
+module Operations
+  module Documents
+    class List
+      include Traits::S3Operation
+
+      attr_accessor :usn
+
+      def initialize(usn:)
+        @usn = usn
+      end
+
+      def call
+        documents = bucket.objects(prefix:).map do |obj|
+          {
+            object_key: obj.key,
+            size: obj.size,
+            last_modified: obj.last_modified.iso8601,
+          }
+        end
+      rescue StandardError => e
+        raise Errors::DocumentUploadError, e
+      ensure
+        log(prefix: prefix, count: documents.try(:count))
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v1/documents/list_spec.rb
+++ b/spec/api/datastore/v1/documents/list_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'list documents by USN' do
+  let(:operation_class) { Operations::Documents::List }
+  let(:stubbed_operation) { instance_double(operation_class, call: {}) }
+
+  let(:usn) { 123 }
+
+  before do
+    allow(
+      operation_class
+    ).to receive(:new).with(usn:).and_return(stubbed_operation)
+  end
+
+  describe 'GET /documents/:usn' do
+    subject(:api_request) do
+      get "/api/v1/documents/#{usn}"
+    end
+
+    it_behaves_like 'a documents API endpoint'
+
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply crime-review] do
+      before { api_request }
+    end
+  end
+end

--- a/spec/services/operations/documents/list_spec.rb
+++ b/spec/services/operations/documents/list_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Operations::Documents::List do
+  subject { described_class.new(usn:) }
+
+  let(:usn) { 123 }
+
+  describe '#call' do
+    include_context 'with an S3 client'
+
+    context 'when there is no error' do
+      let(:stubbed_s3_client) do
+        Aws::S3::Client.new(
+          stub_responses: {
+            list_objects_v2: { contents: [{ key: '123/filename', size: 50, last_modified: Time.zone.at(0) }] }
+          }
+        )
+      end
+
+      before do
+        allow(Aws::S3::Client).to receive(:new).and_return(stubbed_s3_client)
+      end
+
+      it 'performs the listing and logs the operation' do
+        expect(subject.call).to eq([{ last_modified: '1970-01-01T00:00:00Z', object_key: '123/filename', size: 50 }])
+
+        expect(logger).to have_received(:info).with(
+          [
+            '[Operations::Documents::List]',
+            { prefix: '123/', count: 1 }.to_json
+          ].join(' ')
+        )
+      end
+    end
+
+    context 'when there is an error' do
+      let(:endpoint) { 'https://s3.eu-west-2.amazonaws.com/s3_bucket_name/?list-type=2&prefix=123/' }
+
+      before do
+        stub_request(:get, endpoint)
+          .to_raise(StandardError.new('boom!'))
+      end
+
+      it 'logs the operation and re-raises the exception' do
+        expect { subject.call }.to raise_error(Errors::DocumentUploadError)
+
+        expect(logger).to have_received(:error).with(
+          [
+            '[Operations::Documents::List]',
+            { prefix: '123/', count: nil, error: 'boom!' }.to_json
+          ].join(' ')
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Following up with remaining document operations.

I will raise a counterpart PR on the datastore API gem to be able to call this new endpoint.

I've shared on slack a document on how to test these PRs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-525

## Notes for reviewer / how to test
It may be we never need this endpoint or to list bucket files directly, in that case this can be deleted later on, but for now it kind of helps with the development and to ensure we have complete API that can be later on reduced/adapted.