### PR TITLE
CRIMAP-525 Implement upload document endpoint

### DIFF
--- a/app/api/datastore/v1/documents.rb
+++ b/app/api/datastore/v1/documents.rb
@@ -53,6 +53,23 @@ module Datastore
             ).call
           end
         end
+
+        desc 'Upload a document.'
+        route_setting :authorised_consumers, %w[crime-apply]
+        params do
+          requires :usn, type: Integer, desc: 'Application USN.'
+          requires :file, type: File, desc: 'The document file.'
+          requires :payload, type: JSON, desc: 'JSON payload with any additional options.' do
+            requires :filename, type: String
+          end
+        end
+        route_param :usn do
+          post do
+            Operations::Documents::Upload.new(
+              **declared(params).symbolize_keys
+            ).call
+          end
+        end
       end
     end
   end

--- a/app/services/operations/documents/upload.rb
+++ b/app/services/operations/documents/upload.rb
@@ -1,0 +1,40 @@
+module Operations
+  module Documents
+    class Upload
+      include Traits::S3Operation
+
+      attr_accessor :usn, :file, :filename
+
+      delegate :size, to: :tempfile
+
+      def initialize(usn:, file:, payload:)
+        @usn = usn
+        @file = file
+        @filename = payload.fetch('filename')
+      end
+
+      def call
+        object.upload_file(tempfile)
+
+        {
+          object_key:,
+          size:,
+        }
+      rescue StandardError => e
+        raise Errors::DocumentUploadError, e
+      ensure
+        log(object_key:, file_type:, size:)
+      end
+
+      private
+
+      def tempfile
+        file.try(:tempfile) || file.try(:[], 'tempfile')
+      end
+
+      def file_type
+        file.try(:content_type) || file.try(:[], 'type')
+      end
+    end
+  end
+end

--- a/spec/api/datastore/v1/documents/upload_spec.rb
+++ b/spec/api/datastore/v1/documents/upload_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'upload a document' do
+  let(:operation_class) { Operations::Documents::Upload }
+  let(:stubbed_operation) { instance_double(operation_class, call: {}) }
+
+  let(:usn) { 123 }
+  let(:file) { nil } # not testing here the file object
+  let(:payload) { { 'filename' => 'filename' } }
+
+  before do
+    allow(
+      operation_class
+    ).to receive(:new).with(usn:, file:, payload:).and_return(stubbed_operation)
+  end
+
+  describe 'POST /documents/:usn' do
+    subject(:api_request) do
+      post "/api/v1/documents/#{usn}", params: { file:, payload: }
+    end
+
+    it_behaves_like 'a documents API endpoint'
+
+    it_behaves_like 'an authorisable endpoint', %w[crime-apply] do
+      before { api_request }
+    end
+  end
+end

--- a/spec/services/operations/documents/upload_spec.rb
+++ b/spec/services/operations/documents/upload_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Operations::Documents::Upload do
+  subject { described_class.new(usn:, file:, payload:) }
+
+  let(:usn) { 123 }
+  let(:file) { fixture_file_upload('test.pdf', 'application/pdf') }
+  let(:payload) { { 'filename' => 'filename' } }
+
+  describe '#call' do
+    include_context 'with an S3 client'
+
+    context 'when there is no error' do
+      let(:stubbed_s3_client) do
+        Aws::S3::Client.new(
+          stub_responses: { put_object: {} }
+        )
+      end
+
+      before do
+        allow(Aws::S3::Client).to receive(:new).and_return(stubbed_s3_client)
+      end
+
+      it 'performs the upload and logs the operation' do
+        expect(subject.call).to eq({ object_key: '123/filename', size: 14_077 })
+
+        expect(logger).to have_received(:info).with(
+          [
+            '[Operations::Documents::Upload]',
+            { object_key: '123/filename', file_type: 'application/pdf', size: 14_077 }.to_json
+          ].join(' ')
+        )
+      end
+    end
+
+    context 'when there is an error' do
+      let(:endpoint) { 'https://s3.eu-west-2.amazonaws.com/s3_bucket_name/123/filename' }
+
+      before do
+        stub_request(:put, endpoint)
+          .to_raise(StandardError.new('boom!'))
+      end
+
+      it 'logs the operation and re-raises the exception' do
+        expect { subject.call }.to raise_error(Errors::DocumentUploadError)
+
+        expect(logger).to have_received(:error).with(
+          [
+            '[Operations::Documents::Upload]',
+            { object_key: '123/filename', file_type: 'application/pdf', size: 14_077, error: 'boom!' }.to_json
+          ].join(' ')
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Following up with remaining document operations.

I will raise a counterpart PR on the datastore API gem to be able to call this new endpoint.

I've shared on slack a document on how to test these PRs.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-525

## Notes for reviewer / how to test
Note: this endpoint in theory should not be necessary if we are going to use **presigned** upload URLs but adding it here for completeness, marking as do not merge, can be checkout manually to test or use it, or we can decide we want it. Either way is not very useful until we have an interface.