### PR TITLE
Docker compose works with apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.2.2-alpine3.18
 MAINTAINER LAA Crime Apply Team
 
 RUN apk --no-cache add --virtual build-deps build-base postgresql-dev git bash curl \
- && apk --no-cache add postgresql-client tzdata
+ && apk --no-cache add postgresql-client tzdata gcompat
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup && \


### PR DESCRIPTION
## Description of change
Add gcombat and to allow ```docker-compose up``` with Apple Silicon

## Link to relevant ticket

## Notes for reviewer / how to test
To make sure this does not introduce a regression on Intel Mac, remove any docker files you may already have and run ```docker-compose up```