### PR TITLE
Log to stdout in production

### DIFF
--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -8,6 +8,7 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
+  RAILS_LOG_TO_STDOUT: enabled
   ENABLE_PROMETHEUS_EXPORTER: "true"
   # Datastore is accessed via local cluster networking (no SSL)
   DISABLE_HTTPS: enabled

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -8,6 +8,7 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
+  RAILS_LOG_TO_STDOUT: enabled
   ENABLE_PROMETHEUS_EXPORTER: "true"
   # Datastore is accessed via local cluster networking (no SSL)
   DISABLE_HTTPS: enabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
       RAILS_SERVE_STATIC_FILES: "1"
+      RAILS_LOG_TO_STDOUT: "1"
       ENABLE_PROMETHEUS_EXPORTER: "false" # can be enabled for quick tests
       PROMETHEUS_EXPORTER_PORT: 9397
       API_AUTH_SECRET_APPLY: foobar


### PR DESCRIPTION
## Description of change
fluent bit ingests the logs from stdout in the pods for post processing like kibana etc.

I think some logging was not showing up in the pods due to this not being configured in the config_map.
