### PR TITLE
Revert "Log to stdout in production (#146)"

### DIFF
--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -8,7 +8,6 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
-  RAILS_LOG_TO_STDOUT: enabled
   ENABLE_PROMETHEUS_EXPORTER: "true"
   # Datastore is accessed via local cluster networking (no SSL)
   DISABLE_HTTPS: enabled

--- a/config/kubernetes/staging/config_map.yml
+++ b/config/kubernetes/staging/config_map.yml
@@ -8,7 +8,6 @@ data:
   RACK_ENV: production
   RAILS_ENV: production
   RAILS_SERVE_STATIC_FILES: enabled
-  RAILS_LOG_TO_STDOUT: enabled
   ENABLE_PROMETHEUS_EXPORTER: "true"
   # Datastore is accessed via local cluster networking (no SSL)
   DISABLE_HTTPS: enabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
       DATABASE_SSLMODE: disable
       DISABLE_HTTPS: "1"
       RAILS_SERVE_STATIC_FILES: "1"
-      RAILS_LOG_TO_STDOUT: "1"
       ENABLE_PROMETHEUS_EXPORTER: "false" # can be enabled for quick tests
       PROMETHEUS_EXPORTER_PORT: 9397
       API_AUTH_SECRET_APPLY: foobar


### PR DESCRIPTION
This reverts commit 274e3952fff1f6b1bcde31b4508a3e330934555d.

## Description of change
I'm reverting these changes because despite having the expected outcome (Rails.logger.info now shows up), unfortunately in addition to this it also logs every single request (including ping/healthchecks) which is too noisy and has no value at all.

A different approach will be investigated.