### PR TITLE
Allow MAAT adapter dev and uat to use staging

### DIFF
--- a/app/api/datastore/v1/maat/applications.rb
+++ b/app/api/datastore/v1/maat/applications.rb
@@ -4,7 +4,7 @@ module Datastore
       class Applications < Base
         version 'v1', using: :path
 
-        route_setting :authorised_consumers, %w[maat-adapter]
+        route_setting :authorised_consumers, %w[maat-adapter maat-adapter-dev maat-adapter-uat]
 
         resource :applications do
           desc 'Return an application by USN.'

--- a/config/initializers/simple_jwt_auth.rb
+++ b/config/initializers/simple_jwt_auth.rb
@@ -15,6 +15,10 @@ Rails.application.config.to_prepare do
       'crime-apply' => ENV.fetch('API_AUTH_SECRET_APPLY', nil),
       'crime-review' => ENV.fetch('API_AUTH_SECRET_REVIEW', nil),
       'maat-adapter' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER', nil),
+      # MAAT has more non-prod environments than we have, but
+      # they are pointing these non-prod to our staging datastore
+      'maat-adapter-dev' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER_DEV', nil),
+      'maat-adapter-uat' => ENV.fetch('API_AUTH_SECRET_MAAT_ADAPTER_UAT', nil),
     }
   end
 end

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -83,6 +83,16 @@ spec:
               secretKeyRef:
                 name: api-auth-secrets
                 key: maat_adapter
+          - name: API_AUTH_SECRET_MAAT_ADAPTER_DEV
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: maat_adapter_dev
+          - name: API_AUTH_SECRET_MAAT_ADAPTER_UAT
+            valueFrom:
+              secretKeyRef:
+                name: api-auth-secrets
+                key: maat_adapter_uat
           - name: EVENTS_SNS_TOPIC_ARN
             valueFrom:
               secretKeyRef:

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'get application ready for maat' do
     let(:application_usn) { application.submitted_application['reference'] }
     let(:maat_application) { JSON.parse(response.body) }
 
-    it_behaves_like 'an authorisable endpoint', %w[maat-adapter] do
+    it_behaves_like 'an authorisable endpoint', %w[maat-adapter maat-adapter-dev maat-adapter-uat] do
       before { api_request }
     end
 


### PR DESCRIPTION
## Description of change
New API secrets for MAAT `dev` and `uat` have been injected in their corresponding namespaces and these changes are needed to pick them from the ENV and use them with the JWT authentication.

Their previous solution was to manually hardcode the staging secret so this is an improvement until they move to use a mock sometime in the future.

## Link to relevant ticket
Slack thread: https://mojdt.slack.com/archives/C04FQ5404KF/p1692010309264049

## Notes for reviewer / how to test
