### PR TITLE
Update postgresSql clients to fix vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:3.2.2-alpine3.18
 MAINTAINER LAA Crime Apply Team
 
-RUN apk --no-cache add --virtual build-deps build-base postgresql-dev git bash curl \
- && apk --no-cache add postgresql-client tzdata gcompat
+RUN apk --no-cache add --virtual build-deps build-base postgresql15-dev git bash curl \
+ && apk --no-cache add postgresql15-client tzdata gcompat
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup && \


### PR DESCRIPTION
## Description of change
The postgresql-dev and postgresql-client packages used in the Dockerfile were outdated, now that we are running postgres 15.x (locally, CI and also cloud platform through RDS).

This ensure alpine build the image using latest versions of the postgres libraries.