### PR TITLE
Add irsa service account name to staging

### DIFF
--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -20,6 +20,7 @@ spec:
         app: laa-criminal-applications-datastore-web-staging
         tier: frontend
     spec:
+      serviceAccountName: laa-criminal-applications-datastore-staging-service
       containers:
       - name: webapp
         image: ${ECR_URL}:${IMAGE_TAG}


### PR DESCRIPTION
## Description of change
Updates staging Kubernetes manifest to set the irsa service account name. More here:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/accessing-aws-apis-and-resources-from-your-namespace.html#using-irsa-in-your-namespace

## Link to relevant ticket

## Notes for reviewer / how to test
