### PR TITLE
Remove sns topic access keys

### DIFF
--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -99,16 +99,6 @@ spec:
               secretKeyRef:
                 name: application-events-sns-topic
                 key: topic_arn
-          - name: EVENTS_SNS_TOPIC_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: application-events-sns-topic
-                key: access_key_id
-          - name: EVENTS_SNS_TOPIC_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: application-events-sns-topic
-                key: secret_access_key
           - name: S3_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Description of change
Removes no longer required long term creds for sanity checking on staging

## Link to relevant ticket

## Notes for reviewer / how to test
