### PR TITLE
Remove default env fallbacks

### DIFF
--- a/app/services/messaging/events_publisher.rb
+++ b/app/services/messaging/events_publisher.rb
@@ -43,8 +43,8 @@ module Messaging
 
     def credentials
       Aws::AssumeRoleWebIdentityCredentials.new(
-        role_arn: ENV.fetch('AWS_ROLE_ARN', ''),
-        web_identity_token_file: ENV.fetch('AWS_WEB_IDENTITY_TOKEN_FILE', ''),
+        role_arn: ENV.fetch('AWS_ROLE_ARN'),
+        web_identity_token_file: ENV.fetch('AWS_WEB_IDENTITY_TOKEN_FILE'),
         region: region
       )
     end


### PR DESCRIPTION
## Description of change
Remove fallback default strings to ensure `ENV.fetch` fails with an exception

## Link to relevant ticket

## Notes for reviewer / how to test
