### PR TITLE
Replace deprecated credentials for s3

### DIFF
--- a/app/services/operations/documents/traits/s3_operation.rb
+++ b/app/services/operations/documents/traits/s3_operation.rb
@@ -8,8 +8,6 @@ module Operations
           @client ||= Aws::S3::Client.new(
             **{
               endpoint:,
-              access_key_id:,
-              secret_access_key:,
               region:
             }.merge(default_client_cfg).compact_blank
           )
@@ -51,14 +49,6 @@ module Operations
 
         def bucket_name
           ENV.fetch('S3_BUCKET_NAME', nil)
-        end
-
-        def access_key_id
-          ENV.fetch('S3_ACCESS_KEY_ID', nil)
-        end
-
-        def secret_access_key
-          ENV.fetch('S3_SECRET_ACCESS_KEY', nil)
         end
 
         def region

--- a/app/services/operations/documents/traits/s3_operation.rb
+++ b/app/services/operations/documents/traits/s3_operation.rb
@@ -8,6 +8,7 @@ module Operations
           @client ||= Aws::S3::Client.new(
             **{
               endpoint:,
+              credentials:,
               region:
             }.merge(default_client_cfg).compact_blank
           )
@@ -49,6 +50,14 @@ module Operations
 
         def bucket_name
           ENV.fetch('S3_BUCKET_NAME', nil)
+        end
+
+        def credentials
+          Aws::AssumeRoleWebIdentityCredentials.new(
+            role_arn: ENV.fetch('AWS_ROLE_ARN'),
+            web_identity_token_file: ENV.fetch('AWS_WEB_IDENTITY_TOKEN_FILE'),
+            region: region
+          )
         end
 
         def region

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -99,16 +99,6 @@ spec:
               secretKeyRef:
                 name: application-events-sns-topic
                 key: topic_arn
-          - name: S3_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: s3-bucket
-                key: access_key_id
-          - name: S3_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: s3-bucket
-                key: secret_access_key
           - name: S3_BUCKET_NAME
             valueFrom:
               secretKeyRef:

--- a/spec/services/messaging/events_publisher_spec.rb
+++ b/spec/services/messaging/events_publisher_spec.rb
@@ -9,55 +9,6 @@ describe Messaging::EventsPublisher do
     )
   end
 
-  # Example raw XML document received by Aws::AssumeRoleWebIdentityCredentials
-  # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
-  let(:sts_xml) do
-    <<-XML
-      <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-      <AssumeRoleWithWebIdentityResult>
-        <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
-        <Audience>client.5498841531868486423.1548@the-role-session-name</Audience>
-        <AssumedRoleUser>
-          <Arn>role_arn</Arn>
-          <AssumedRoleId>AROACLKWSDQRAOEXAMPLE:the-role-session-name</AssumedRoleId>
-        </AssumedRoleUser>
-        <Credentials>
-          <SessionToken>AQoDYXdzEE0a8ANXXXXXXXXNO1ewxE5TijQyp+IEXAMPLE</SessionToken>
-          <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
-          <Expiration>2014-10-24T23:00:23Z</Expiration>
-          <AccessKeyId>ASgeIAIOSFODNN7EXAMPLE</AccessKeyId>
-        </Credentials>
-        <SourceIdentity>SourceIdentityValue</SourceIdentity>
-        <Provider>www.amazon.com</Provider>
-      </AssumeRoleWithWebIdentityResult>
-      <ResponseMetadata>
-        <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
-      </ResponseMetadata>
-      </AssumeRoleWithWebIdentityResponse>
-    XML
-  end
-
-  before do
-    stub_request(:post, 'https://sts.eu-west-2.amazonaws.com/')
-      .with(
-        body: {
-          'Action' => 'AssumeRoleWithWebIdentity',
-          'RoleArn' => 'role_arn',
-          'RoleSessionName' => /.*/,
-          'Version' => '2011-06-15',
-          'WebIdentityToken' => /.*/
-        },
-        headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => '',
-          'Content-Length' => '796',
-          'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
-          'User-Agent' => %r{aws-sdk-ruby3/.*}
-        }
-      )
-      .to_return(status: 200, body: sts_xml, headers: {})
-  end
-
   describe '.publish' do
     let(:instance) { instance_double(described_class, publish: true) }
 
@@ -72,6 +23,8 @@ describe Messaging::EventsPublisher do
   end
 
   describe '#publish' do
+    include_context 'with a stubbed AWS credentials request'
+
     let(:sns_endpoint) { 'https://sns.eu-west-2.amazonaws.com' }
 
     before do

--- a/spec/services/operations/documents/delete_spec.rb
+++ b/spec/services/operations/documents/delete_spec.rb
@@ -14,6 +14,7 @@ describe Operations::Documents::Delete do
 
   describe '#call' do
     include_context 'with an S3 client'
+    include_context 'with a stubbed AWS credentials request'
 
     let(:endpoint) { 'https://s3.eu-west-2.amazonaws.com/s3_bucket_name/123/filename' }
 

--- a/spec/services/operations/documents/list_spec.rb
+++ b/spec/services/operations/documents/list_spec.rb
@@ -7,6 +7,7 @@ describe Operations::Documents::List do
 
   describe '#call' do
     include_context 'with an S3 client'
+    include_context 'with a stubbed AWS credentials request'
 
     context 'when there is no error' do
       let(:stubbed_s3_client) do

--- a/spec/services/operations/documents/presign_url_spec.rb
+++ b/spec/services/operations/documents/presign_url_spec.rb
@@ -9,6 +9,7 @@ describe Operations::Documents::PresignUrl do
 
   describe '#call' do
     include_context 'with an S3 client'
+    include_context 'with a stubbed AWS credentials request'
 
     context 'when there is no error' do
       context 'when downloading files' do

--- a/spec/support/shared_examples/document_operations.rb
+++ b/spec/support/shared_examples/document_operations.rb
@@ -9,6 +9,9 @@ RSpec.shared_context 'with an S3 client' do
       'ENV',
       ENV.to_h.merge(
         'S3_BUCKET_NAME' => 's3_bucket_name',
+        'AWS_WEB_IDENTITY_TOKEN_FILE' => File.expand_path('../../fixtures/aws/web_identity_token',
+                                                          File.dirname(__FILE__)),
+        'AWS_ROLE_ARN' => 'role_arn'
       )
     )
   end

--- a/spec/support/shared_examples/document_operations.rb
+++ b/spec/support/shared_examples/document_operations.rb
@@ -8,8 +8,6 @@ RSpec.shared_context 'with an S3 client' do
     stub_const(
       'ENV',
       ENV.to_h.merge(
-        'S3_ACCESS_KEY_ID' => 's3_access_key_id',
-        'S3_SECRET_ACCESS_KEY' => 's3_secret_access_key',
         'S3_BUCKET_NAME' => 's3_bucket_name',
       )
     )

--- a/spec/support/shared_examples/stubbed_aws_request.rb
+++ b/spec/support/shared_examples/stubbed_aws_request.rb
@@ -1,0 +1,50 @@
+RSpec.shared_context 'with a stubbed AWS credentials request' do
+  # Example raw XML document received by Aws::AssumeRoleWebIdentityCredentials
+  # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+  let(:sts_xml) do
+    <<-XML
+      <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+      <AssumeRoleWithWebIdentityResult>
+        <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
+        <Audience>client.5498841531868486423.1548@the-role-session-name</Audience>
+        <AssumedRoleUser>
+          <Arn>role_arn</Arn>
+          <AssumedRoleId>AROACLKWSDQRAOEXAMPLE:the-role-session-name</AssumedRoleId>
+        </AssumedRoleUser>
+        <Credentials>
+          <SessionToken>AQoDYXdzEE0a8ANXXXXXXXXNO1ewxE5TijQyp+IEXAMPLE</SessionToken>
+          <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+          <Expiration>2014-10-24T23:00:23Z</Expiration>
+          <AccessKeyId>ASgeIAIOSFODNN7EXAMPLE</AccessKeyId>
+        </Credentials>
+        <SourceIdentity>SourceIdentityValue</SourceIdentity>
+        <Provider>www.amazon.com</Provider>
+      </AssumeRoleWithWebIdentityResult>
+      <ResponseMetadata>
+        <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+      </ResponseMetadata>
+      </AssumeRoleWithWebIdentityResponse>
+    XML
+  end
+
+  before do
+    stub_request(:post, 'https://sts.eu-west-2.amazonaws.com/')
+      .with(
+        body: {
+          'Action' => 'AssumeRoleWithWebIdentity',
+          'RoleArn' => 'role_arn',
+          'RoleSessionName' => /.*/,
+          'Version' => '2011-06-15',
+          'WebIdentityToken' => /.*/
+        },
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => '',
+          'Content-Length' => '796',
+          'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
+          'User-Agent' => %r{aws-sdk-ruby3/.*}
+        }
+      )
+      .to_return(status: 200, body: sts_xml, headers: {})
+  end
+end


### PR DESCRIPTION
## Description of change
Long lived credentials are being removed from AWS services and datastore staging is currently failing to build due to the deprecated credentials being referenced in the code. Therefore this PR replaces the credentials to pass in the new short lived credentials and updates tests.

## Link to relevant ticket
[CRIMAP-577](https://dsdmoj.atlassian.net/browse/CRIMAP-577)

## Notes for reviewer / how to test


[CRIMAP-577]: https://dsdmoj.atlassian.net/browse/CRIMAP-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ