### PR TITLE
CRIMAP-574 maat api returns completed applications

### DIFF
--- a/app/api/datastore/v1/maat/applications.rb
+++ b/app/api/datastore/v1/maat/applications.rb
@@ -16,7 +16,10 @@ module Datastore
               Datastore::Entities::V1::MAAT::Application.represent(
                 CrimeApplication.find_by!(
                   reference: params[:usn],
-                  review_status: Types::ReviewApplicationStatus['ready_for_assessment']
+                  review_status: [
+                    Types::ReviewApplicationStatus['ready_for_assessment'],
+                    Types::ReviewApplicationStatus['assessment_completed']
+                  ]
                 )
               )
             end

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -82,7 +82,13 @@ RSpec.describe 'get application ready for maat' do
         api_request
       end
 
-      it_behaves_like 'an error that raises a 404 status code'
+      it 'returns http status 200' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns the completed application' do
+        expect(maat_application['reference']).to match(application.submitted_application['reference'])
+      end
     end
 
     context 'with a returned application' do


### PR DESCRIPTION
## Description of change
Enable MAAT to retrieve data from Review when the application status in Review is 'Complete'.

This is a temporary solution to allow Caseworkers to continue processing in MAAT even if they mark the application as 'Complete' prematurely in Review.

## Link to relevant ticket
[CRIMAP-574](https://dsdmoj.atlassian.net/browse/CRIMAP-574)

## Notes for reviewer / how to test


[CRIMAP-574]: https://dsdmoj.atlassian.net/browse/CRIMAP-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ