### PR TITLE
Avoid workflow incorrectly mark ECR output as secret

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}
+          mask-aws-account-id: 'false'
 
       # Login to container repository
       - uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
## Description of change
This is a [known issue](https://github.com/orgs/community/discussions/37942) where some patterns and masks are detected as secrets by github workflow and forbids certain action, like in this case, we want to propagate the `ecr_url` output to the deploy action.

Hopefully this works.

## Link to relevant ticket

## Notes for reviewer / how to test
