### PR TITLE
Bump aws action to v3

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
 
       # Assume role in Cloud Platform
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.ECR_REGION }}


### PR DESCRIPTION
## Description of change
This is suppose to fix the problem with incorrectly considering the ECR a secret (and thus not being able to propagate the value to the deploy action) as well as some deprecation warnings.

More info:
https://github.com/aws-actions/configure-aws-credentials#news

## Link to relevant ticket

## Notes for reviewer / how to test
