### PR TITLE
Return empty array if no supporting evidence

### DIFF
--- a/app/api/datastore/entities/v1/crime_application.rb
+++ b/app/api/datastore/entities/v1/crime_application.rb
@@ -23,7 +23,7 @@ module Datastore
         end
 
         def supporting_evidence
-          submitted_value('supporting_evidence')
+          submitted_value('supporting_evidence') || []
         end
       end
     end


### PR DESCRIPTION
## Description of change
Fixes staging issue where crime applications could not be opened as applications with no supporting evidence were not being handled. Returns an empty array if nil 

## Link to relevant ticket

## Notes for reviewer / how to test
