### PR TITLE
Redact supporting evidence

### DIFF
--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -23,6 +23,10 @@ module Redacting
         redact: %w[reason],
         type: :array # [{}, {}, ...]
       },
+      'supporting_evidence' => {
+        redact: %w[s3_object_key filename],
+        type: :array # [{}, {}, ...]
+      },
     }.freeze
 
     def self.pii_attributes

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -79,6 +79,21 @@ describe Redacting::Redact do
         )
       end
     end
+
+    context 'with supporting evidence' do
+      let(:supporting_evidence) { redacted_application['supporting_evidence'] }
+
+      it 'redacts the expected attributes' do
+        expect(supporting_evidence).to eq(
+          [{
+            's3_object_key' => '__redacted__',
+            'filename' => '__redacted__',
+            'file_size' => 12,
+            'content_type' => 'application/pdf',
+          }]
+        )
+      end
+    end
   end
 
   describe 'metadata attributes' do

--- a/spec/services/redacting/rules_spec.rb
+++ b/spec/services/redacting/rules_spec.rb
@@ -14,6 +14,7 @@ describe Redacting::Rules do
           client_details.applicant.home_address
           case_details.codefendants
           interests_of_justice
+          supporting_evidence
         ]
       )
     end


### PR DESCRIPTION
## Description of change
For now we are keeping the collection but with some redacted attributes. We can re-evaluate.

## Notes for reviewer / how to test
Submit an application with evidence. Open a datastore console and retrieve the submitted application and its redacted record. JSON for evidence should look similar to this:

```
"supporting_evidence"=>
  [{"filename"=>"__redacted__", "file_size"=>122796, "content_type"=>"image/png", "s3_object_key"=>"__redacted__"},
   {"filename"=>"__redacted__", "file_size"=>128267, "content_type"=>"image/png", "s3_object_key"=>"__redacted__"},
   {"filename"=>"__redacted__", "file_size"=>156941, "content_type"=>"image/png", "s3_object_key"=>"__redacted__"}]
``` 