### PR TITLE
Add benefit type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 28f7cddb1b6e2f23bb93724282a9ce6296df966e
-  tag: v1.0.1
+  revision: 1d653fab9b4a666c31321189552ed4b0033ef4de
+  tag: v1.0.2
   specs:
     laa-criminal-legal-aid-schemas (1.0.0)
       dry-struct (~> 1.6.0)

--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -12,7 +12,7 @@ module Datastore
     end
 
     rescue_from ActiveRecord::RecordNotUnique do
-      error!({ status: 400, error: 'Record not unique' }, 400)
+      error!({ status: 409, error: 'Record not unique' }, 409)
     end
 
     rescue_from LaaCrimeSchemas::Errors::ValidationError do |ex|

--- a/app/api/datastore/base.rb
+++ b/app/api/datastore/base.rb
@@ -11,24 +11,24 @@ module Datastore
       error!({ status: 404, error: 'Record not found' }, 404)
     end
 
-    rescue_from ActiveRecord::RecordNotUnique do
-      error!({ status: 409, error: 'Record not unique' }, 409)
-    end
-
     rescue_from LaaCrimeSchemas::Errors::ValidationError do |ex|
       error!({ status: 400, error: ex.message }, 400)
     end
 
+    rescue_from Errors::AlreadySubmitted do
+      error!({ status: 409, error: 'Application already submitted' }, 409)
+    end
+
     rescue_from Errors::AlreadyReturned do
-      error!({ status: 409, error: 'Already Returned' }, 409)
+      error!({ status: 409, error: 'Application already returned' }, 409)
     end
 
     rescue_from Errors::AlreadyCompleted do
-      error!({ status: 409, error: 'Already Completed' }, 409)
+      error!({ status: 409, error: 'Application already completed' }, 409)
     end
 
     rescue_from Errors::AlreadyMarkedAsReady do
-      error!({ status: 409, error: 'Already marked as ready' }, 409)
+      error!({ status: 409, error: 'Application already marked as ready' }, 409)
     end
 
     rescue_from Errors::DocumentUploadError do |ex|

--- a/app/lib/errors.rb
+++ b/app/lib/errors.rb
@@ -1,4 +1,7 @@
 module Errors
+  class AlreadySubmitted < StandardError
+  end
+
   class AlreadyReturned < StandardError
   end
 

--- a/app/services/operations/create_application.rb
+++ b/app/services/operations/create_application.rb
@@ -20,6 +20,8 @@ module Operations
       end
 
       { id: @app.id }
+    rescue ActiveRecord::RecordNotUnique
+      raise Errors::AlreadySubmitted
     end
 
     private

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
     end
   end
 
+  context 'when the "supporting_evidence" key is not in the submitted application' do
+    let(:submitted_application) do
+      super().delete('submitted_application')
+    end
+
+    it 'represents the supporting evidence as an empty array' do
+      expect(representation.fetch('supporting_evidence')).to eq []
+    end
+  end
+
   context 'when retrieved from the database' do
     it 'represents submitted_at' do
       expect(representation.fetch('submitted_at')).to eq submitted_at.iso8601(3)

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe 'create application' do
         api_request
       end
 
-      it 'returns 400' do
-        expect(response).to have_http_status(:bad_request)
+      it 'returns 409' do
+        expect(response).to have_http_status(:conflict)
       end
 
       it 'returns error information' do

--- a/spec/api/datastore/v1/applications/create_application_spec.rb
+++ b/spec/api/datastore/v1/applications/create_application_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'create application' do
       end
 
       it 'returns error information' do
-        expect(response.body).to include('Record not unique')
+        expect(response.body).to include('Application already submitted')
       end
 
       it 'does not publish a submission event' do

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -48,6 +48,7 @@ describe Redacting::Redact do
             'country' => 'United Kingdom',
             'postcode' => 'SW1A 2AA',
           },
+          'benefit_type' => 'universal_credit',
           'correspondence_address' => nil
         })
       end


### PR DESCRIPTION
## Description of change

Update to use same schema version as Apply and Review (which includes "benefit_type")
Return 409 when a duplicate is found on create application
Spec case when submitted application does not include "supporting_evidence"

## Link to relevant ticket

## Notes for reviewer / how to test
