### PR TITLE
[CRIMAP-675] Update schema gem to 1.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.4'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.5'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 41045dd32b5f821ff4919a88fd31c9c7a91a7177
-  tag: v1.0.4
+  revision: 1e08dfd8e71f956b06c1f8684af3fa465271f624
+  tag: v1.0.5
   specs:
-    laa-criminal-legal-aid-schemas (1.0.4)
+    laa-criminal-legal-aid-schemas (1.0.5)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
@@ -79,7 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.836.0)
+    aws-partitions (1.838.0)
     aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -320,7 +320,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     stringio (3.0.8)
-    thor (1.2.2)
+    thor (1.3.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -92,7 +92,6 @@ describe Redacting::Redact do
             'file_size' => 12,
             'content_type' => 'application/pdf',
             'scan_at' => '2023-10-01 12:34:56',
-            'scan_status' => 'pass',
           }]
         )
       end


### PR DESCRIPTION
## Description of change
Uses latest Schema gem 1.0.5 to allow default values for document.scan_status

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-675

## Notes for reviewer / how to test
N/A