### PR TITLE
CRIMAP-713 Rename trivy prometheus severity label

### DIFF
--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -62,13 +62,22 @@ spec:
 
     - alert: CrimeApplyDatastore-TrivyVulns
       expr: >-
-        sum(trivy_image_vulnerabilities{namespace=~"^laa-criminal-applications-datastore.*", severity=~"Critical|High"} > 0) 
-        by (namespace, image_tag, severity)
+        sum by (namespace, image_tag, trivy_severity) (
+          label_replace(
+            trivy_image_vulnerabilities{namespace=~"^laa-criminal-applications-datastore.*",severity=~"Critical|High"}
+          >
+            0,
+          "trivy_severity",
+          "$1",
+          "severity",
+          "(.*)"
+          )
+        )
       for: 1h
       labels:
         severity: laa-crime-apply-alerts
       annotations:
-        message: Image `{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.severity }} vulnerabilities.
+        message: Image `{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.trivy_severity }} vulnerabilities.
         dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/trivy_starboard_operator123/trivy-operator-image-vulnerability?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.namespace }}
 
     - alert: CrimeApplyDatastore-DLQNotEmpty


### PR DESCRIPTION
## Description of change
Rename trivy prometheus severity label

## Link to relevant ticket
[CRIMAP-713](https://dsdmoj.atlassian.net/browse/CRIMAP-713)

## Notes for reviewer / how to test
The label "severity" was causing a collision with CP


[CRIMAP-713]: https://dsdmoj.atlassian.net/browse/CRIMAP-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ