### PR TITLE
[CRIMAP-728] Replicate hearing_court_name into first_court_hearing_name

### DIFF
--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -31,10 +31,11 @@ class CrimeApplication < ApplicationRecord
   # data consistency for reporting and consuming services
   def copy_first_court_hearing_name
     return if submitted_application.blank?
-    return if submitted_application.dig('case_details', 'first_court_hearing_name').present?
-    return if submitted_application.dig('case_details', 'is_first_court_hearing') == 'no'
 
-    hearing_court_name = submitted_application.dig('case_details', 'hearing_court_name')
-    submitted_application['case_details']['first_court_hearing_name'] = hearing_court_name
+    case_details = submitted_application.fetch('case_details')
+    return if case_details['first_court_hearing_name'].present?
+    return if case_details['is_first_court_hearing'] == Types::FirstHearingAnswerValues['no']
+
+    case_details['first_court_hearing_name'] = case_details['hearing_court_name']
   end
 end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -1,3 +1,5 @@
+require 'laa_crime_schemas'
+
 class CrimeApplication < ApplicationRecord
   include Redactable
 
@@ -7,6 +9,7 @@ class CrimeApplication < ApplicationRecord
 
   before_validation :shift_payload_attributes, on: :create
   before_validation :set_overall_offence_class, on: :create
+  before_validation :copy_first_court_name, on: :save
 
   private
 
@@ -24,5 +27,14 @@ class CrimeApplication < ApplicationRecord
     self.offence_class = Utils::OffenceClassCalculator.new(
       offences: submitted_application['case_details']['offences']
     ).offence_class
+  end
+
+  # Replicate the 'hearing_court_name' into 'first_court_hearing_name' even though they
+  # are assumed to be the same when `is_first_court_hearing = yes`
+  def copy_first_court_name
+    return if first_court_name.present?
+    return if is_first_court_hearing != LaaCrimeSchemas::Types::FirstHearingAnswerValues['yes']
+
+    self.first_court_name = hearing_court_name
   end
 end


### PR DESCRIPTION
## Description of change
Ensures `first_court_hearing_name` value is always populated, rather than being left as `nil` to ensure data integrity and consistency for consuming services.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAP-728

## Notes for reviewer / how to test
- Should there be a data migration fro any applications in production that still have the `first_court_hearing_name = nil` ?
- Is there a more elegant solution that does not involve callbacks e.g. forcing the consuming service (Apply) to always submit the `first_court_hearing_name` (which would mean a similar behaviour in Apply, and any other service)
- Should `first_court_hearing_name` be allowed to be `nil`?
- The spec iterates a through a 'truth table' of combinations, would a simpler set of context/it blocks be better (but repetitive)?
