### PR TITLE
[CRIMAP-726] Calculate work stream of application at point of submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.5'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.6'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1e08dfd8e71f956b06c1f8684af3fa465271f624
-  tag: v1.0.5
+  revision: 1f45f2cbc3c9d4c7defe81b0dc182f549550d46f
+  tag: v1.0.6
   specs:
-    laa-criminal-legal-aid-schemas (1.0.5)
+    laa-criminal-legal-aid-schemas (1.0.6)
+      dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
@@ -116,13 +117,25 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    dry-configurable (1.1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
     dry-core (1.0.1)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
     dry-inflector (1.0.0)
+    dry-initializer (3.1.1)
     dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-schema (1.13.3)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-logic (>= 1.4, < 2)
+      dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
     dry-struct (1.6.0)
       dry-core (~> 1.0, < 2)

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -18,6 +18,7 @@ module Datastore
               # TODO: clarify with MAAT if they need the first court hearing details
               'is_first_court_hearing',
               'first_court_hearing_name',
+              'work_stream'
             )
           end
         end

--- a/app/models/crime_application.rb
+++ b/app/models/crime_application.rb
@@ -6,7 +6,7 @@ class CrimeApplication < ApplicationRecord
   enum review_status: Types::ReviewApplicationStatus.mapping
 
   before_validation :shift_payload_attributes, on: :create
-  before_validation :set_overall_offence_class, on: :create
+  before_validation :set_overall_offence_class, :set_work_stream, on: :create
   before_save :copy_first_court_hearing_name
 
   private
@@ -37,5 +37,13 @@ class CrimeApplication < ApplicationRecord
     return if case_details['is_first_court_hearing'] == Types::FirstHearingAnswerValues['no']
 
     case_details['first_court_hearing_name'] = case_details['hearing_court_name']
+  end
+
+  def set_work_stream
+    return unless submitted_application
+
+    self.work_stream = Utils::WorkStreamCalculator.new(
+      first_court_name: submitted_application['case_details']['first_court_hearing_name']
+    ).work_stream
   end
 end

--- a/app/services/utils/work_stream_calculator.rb
+++ b/app/services/utils/work_stream_calculator.rb
@@ -1,0 +1,25 @@
+require 'laa_crime_schemas'
+
+module Utils
+  class WorkStreamCalculator
+    attr_reader :first_court_name
+
+    def initialize(first_court_name:)
+      @first_court_name = first_court_name
+    end
+
+    def work_stream
+      if extradition_case?
+        LaaCrimeSchemas::Types::WorkStreamType['extradition']
+      else
+        LaaCrimeSchemas::Types::WorkStreamType['criminal_applications_team']
+      end
+    end
+
+    private
+
+    def extradition_case?
+      @first_court_name == "Westminster Magistrates' Court"
+    end
+  end
+end

--- a/db/migrate/20231106141454_add_work_stream_to_crime_applications.rb
+++ b/db/migrate/20231106141454_add_work_stream_to_crime_applications.rb
@@ -1,0 +1,6 @@
+class AddWorkStreamToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :crime_applications, :work_stream, :string, null: false, default: 'criminal_applications_team'
+    add_index :crime_applications, :work_stream
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_10_160748) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_06_141454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_10_160748) do
     t.string "offence_class"
     t.virtual "office_code", type: :string, as: "((submitted_application -> 'provider_details'::text) ->> 'office_code'::text)", stored: true
     t.jsonb "return_details"
+    t.string "work_stream"
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -115,4 +115,9 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
   it 'represents the overall offence class within the case details' do
     expect(representation.fetch('case_details').fetch('offence_class')).to eq offence_class
   end
+
+  it 'represents the work stream within the case details' do
+    expect(representation.fetch('case_details')
+                         .fetch('work_stream')).to eq Types::WorkStreamType['criminal_applications_team']
+  end
 end

--- a/spec/services/utils/work_stream_calculator_spec.rb
+++ b/spec/services/utils/work_stream_calculator_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'laa_crime_schemas'
+
+describe Utils::WorkStreamCalculator do
+  subject { described_class.new(first_court_name:) }
+
+  describe 'Work stream calculation' do
+    context 'when calculating for an application with a first court hearing at Westminster magistrates court' do
+      let(:first_court_name) { "Westminster Magistrates' Court" }
+
+      it 'returns an extradition work stream value' do
+        expect(subject.work_stream).to eq LaaCrimeSchemas::Types::WorkStreamType['extradition']
+      end
+    end
+
+    context 'when calculating for an application with no Westminster magistrates court hearing' do
+      let(:first_court_name) { 'Cardiff Crown Court' }
+
+      it 'returns an criminal applications team work stream value' do
+        expect(subject.work_stream).to eq LaaCrimeSchemas::Types::WorkStreamType['criminal_applications_team']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds an a work stream field to the `crime_application` table which is indexed to enable searching on review. When an application is created, the appropriate work steam is calculated and saved. The field is also omitted from maat applications.

## Link to relevant ticket

[CRIMAP-726](https://dsdmoj.atlassian.net/browse/CRIMAP-726)

## Notes for reviewer / how to test


[CRIMAP-726]: https://dsdmoj.atlassian.net/browse/CRIMAP-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ