### PR TITLE
[CRIMAP-66] Add S3 to production

### DIFF
--- a/config/kubernetes/production/deployment.tpl
+++ b/config/kubernetes/production/deployment.tpl
@@ -89,3 +89,8 @@ spec:
               secretKeyRef:
                 name: application-events-sns-topic
                 key: topic_arn
+          - name: S3_BUCKET_NAME
+            valueFrom:
+              secretKeyRef:
+                name: s3-bucket
+                key: bucket_name


### PR DESCRIPTION
## Description of change
Adds S3 bucket to production deployment, based on cloud-platform https://github.com/ministryofjustice/cloud-platform-environments/pull/17713

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-66

## Notes for reviewer / how to test
Test evidence upload via production