### PR TITLE
[CRIMAP-129] Upgrade DB Schema for lost_job_in_custody and schema change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.8'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.9'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 2b107ad1bb618eb1dcd0edebdf4c5e2da20b9c17
-  tag: v1.0.8
+  revision: aa0a86bf5bd66514b74c65ce0b55f4b3a7154d2b
+  tag: v1.0.9
   specs:
-    laa-criminal-legal-aid-schemas (1.0.8)
+    laa-criminal-legal-aid-schemas (1.0.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_141454) do
     t.string "offence_class"
     t.virtual "office_code", type: :string, as: "((submitted_application -> 'provider_details'::text) ->> 'office_code'::text)", stored: true
     t.jsonb "return_details"
-    t.string "work_stream"
+    t.string "work_stream", default: "criminal_applications_team", null: false
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_141454) do
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
     t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
+    t.index ["work_stream"], name: "index_crime_applications_on_work_stream"
   end
 
   create_table "redacted_crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
Schema change to allow `lost_job_in_custody` data

Updates DB schema to include missing default value and index for `work_stream`

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-129

## Notes for reviewer / how to test
Note change to Schema: Index and default value for work_streams was missing in schema even though specified in migration
