### PR TITLE
CRIMAP-129

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.8'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.9'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.9'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.10'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: aa0a86bf5bd66514b74c65ce0b55f4b3a7154d2b
-  tag: v1.0.9
+  revision: 36557b0a9c3973c41a8bb450285516f278606c3b
+  tag: v1.0.10
   specs:
-    laa-criminal-legal-aid-schemas (1.0.9)
+    laa-criminal-legal-aid-schemas (1.0.10)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 2b107ad1bb618eb1dcd0edebdf4c5e2da20b9c17
-  tag: v1.0.8
+  revision: aa0a86bf5bd66514b74c65ce0b55f4b3a7154d2b
+  tag: v1.0.9
   specs:
-    laa-criminal-legal-aid-schemas (1.0.8)
+    laa-criminal-legal-aid-schemas (1.0.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/crime_application.rb
+++ b/app/api/datastore/entities/v1/crime_application.rb
@@ -6,6 +6,7 @@ module Datastore
         expose :parent_id
         expose :created_at
 
+        expose :means_details
         expose :supporting_evidence
         expose :work_stream
 
@@ -26,6 +27,10 @@ module Datastore
 
         def supporting_evidence
           submitted_value('supporting_evidence') || []
+        end
+
+        def means_details
+          submitted_value('means_details') || {}
         end
       end
     end

--- a/app/api/datastore/entities/v1/pruned_application.rb
+++ b/app/api/datastore/entities/v1/pruned_application.rb
@@ -8,6 +8,7 @@ module Datastore
                  :return_details,
                  :ioj_passport,
                  :means_passport,
+                 :means_details,
                  :supporting_evidence,
                  :work_stream
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_141454) do
     t.string "offence_class"
     t.virtual "office_code", type: :string, as: "((submitted_application -> 'provider_details'::text) ->> 'office_code'::text)", stored: true
     t.jsonb "return_details"
-    t.string "work_stream"
+    t.string "work_stream", default: "criminal_applications_team", null: false
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["review_status", "reviewed_at"], name: "index_crime_applications_on_review_status_and_reviewed_at"
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_141454) do
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
     t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
+    t.index ["work_stream"], name: "index_crime_applications_on_work_stream"
   end
 
   create_table "redacted_crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Description of change
Uses latest schema 1.0.10 to enable `means_details` inside `crime_application` for subsequent use in Apply/Review

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-129

## Notes for reviewer / how to test
Is the default empty hash for a `means_details` correct?

```
# In crime_application.rb

def means_details
  submitted_value('means_details') || {}
end
```