### PR TITLE
Use latest work stream name names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.18'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.19'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 8b3013e7ce7e5b55fb7555de49b952b128a3b783
-  tag: v1.0.18
+  revision: 18cd5b3f6c461178be1190ed18b4e0e50cc04f7a
+  tag: v1.0.19
   specs:
-    laa-criminal-legal-aid-schemas (1.0.18)
+    laa-criminal-legal-aid-schemas (1.0.19)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change

Update Schema to use the latest work stream names.

## Link to relevant ticket
[CRIMAPP-254](https://dsdmoj.atlassian.net/browse/CRIMAPP-254)
[CRIMAPP-253](https://dsdmoj.atlassian.net/browse/CRIMAPP-253)

## Notes for reviewer / how to test

Updates to use the following version of the schema:
https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/commit/18cd5b3f6c461178be1190ed18b4e0e50cc04f7a

Required by this Review PR https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/481


[CRIMAPP-254]: https://dsdmoj.atlassian.net/browse/CRIMAPP-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRIMAPP-253]: https://dsdmoj.atlassian.net/browse/CRIMAPP-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ