### PR TITLE
[CRIMAPP-282] Add case and application type to search results

### DIFF
--- a/app/api/datastore/entities/v1/search_result.rb
+++ b/app/api/datastore/entities/v1/search_result.rb
@@ -15,6 +15,8 @@ module Datastore
         expose :return_details
         expose :office_code
         expose :provider_name
+        expose :application_type
+        expose :case_type
 
         private
 
@@ -44,6 +46,14 @@ module Datastore
 
         def reference
           object.submitted_application&.dig('reference').to_i
+        end
+
+        def case_type
+          object.submitted_application&.dig('case_details', 'case_type')
+        end
+
+        def application_type
+          object.submitted_application&.dig('application_type')
         end
       end
     end

--- a/app/api/datastore/v1/searching.rb
+++ b/app/api/datastore/v1/searching.rb
@@ -17,6 +17,7 @@ module Datastore
             optional(:status, type: [String], values: Types::APPLICATION_STATUSES)
             optional(:review_status, type: [String], values: Types::REVIEW_APPLICATION_STATUSES)
             optional(:work_stream, type: [String], values: Types::WORK_STREAM_TYPES)
+            optional(:case_type, type: [String], values: Types::CASE_TYPES)
 
             optional :submitted_after, type: DateTime
             optional :submitted_before, type: DateTime

--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -13,6 +13,7 @@ class SearchFilter
   attribute :reviewed_after, :datetime
   attribute :reviewed_before, :datetime
   attribute :work_stream, array: true, default: -> { [] }
+  attribute :case_type, array: true, default: -> { [] }
 
   def active_filters
     attributes.compact_blank.keys
@@ -73,5 +74,9 @@ class SearchFilter
 
   def filter_search_text(scope)
     scope.where("searchable_text @@ plainto_tsquery('english', ?)", search_text)
+  end
+
+  def filter_case_type(scope)
+    scope.where(case_type:)
   end
 end

--- a/app/models/sorting.rb
+++ b/app/models/sorting.rb
@@ -16,7 +16,8 @@ class Sorting
     return_reason: [:return_reason],
     office_code: [:office_code],
     reference: [:reference],
-    submitted_at: [:submitted_at]
+    submitted_at: [:submitted_at],
+    case_type: [:case_type]
   }.freeze
 
   DEFAULT_SORT_BY = :submitted_at

--- a/db/migrate/20231218161740_add_case_type_virtual_attribute_to_crime_applications.rb
+++ b/db/migrate/20231218161740_add_case_type_virtual_attribute_to_crime_applications.rb
@@ -1,0 +1,14 @@
+class AddCaseTypeVirtualAttributeToCrimeApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :crime_applications,
+      :case_type,
+      :virtual,
+      as: "(submitted_application->'case_details'->>'case_type')",
+      type: :string,
+      stored: true
+    )
+
+    add_index :crime_applications, :case_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_17_142441) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_161740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -31,9 +31,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_142441) do
     t.string "offence_class"
     t.virtual "office_code", type: :string, as: "((submitted_application -> 'provider_details'::text) ->> 'office_code'::text)", stored: true
     t.jsonb "return_details"
-    t.string "work_stream", default: "criminal_applications_team", null: false
+    t.string "work_stream"
     t.virtual "return_reason", type: :string, as: "(return_details ->> 'reason'::text)", stored: true
+    t.virtual "case_type", type: :string, as: "((submitted_application -> 'case_details'::text) ->> 'case_type'::text)", stored: true
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
+    t.index ["case_type"], name: "index_crime_applications_on_case_type"
     t.index ["office_code"], name: "index_crime_applications_on_office_code"
     t.index ["reference"], name: "index_crime_applications_on_reference"
     t.index ["return_reason"], name: "index_crime_applications_on_return_reason"
@@ -43,7 +45,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_142441) do
     t.index ["status", "returned_at"], name: "index_crime_applications_on_status_and_returned_at", order: { returned_at: :desc }
     t.index ["status", "reviewed_at"], name: "index_crime_applications_on_status_and_reviewed_at", order: { reviewed_at: :desc }
     t.index ["status", "submitted_at"], name: "index_crime_applications_on_status_and_submitted_at", order: { submitted_at: :desc }
-    t.index ["work_stream"], name: "index_crime_applications_on_work_stream"
   end
 
   create_table "redacted_crime_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/api/datastore/entities/v1/search_result_spec.rb
+++ b/spec/api/datastore/entities/v1/search_result_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   let(:return_details) { { 'details' => 'There was an issue with the uploaded evidence' } }
   let(:office_code) { 'XYZ123' }
   let(:work_stream) { 'criminal_applications_team' }
+  let(:case_type) { 'summary_only' }
+  let(:application_type) { 'initial' }
 
   let(:submitted_application) do
     LaaCrimeSchemas.fixture(1.0) { |json| json.merge('parent_id' => parent_id) }
@@ -94,6 +96,14 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
       expect(representation.fetch(:return_reason)).to be_nil
       expect(representation.fetch(:return_details)).to be_nil
     end
+  end
+
+  it 'represents the case_type' do
+    expect(representation.fetch(:case_type)).to eq 'appeal_to_crown_court'
+  end
+
+  it 'represents the application_type' do
+    expect(representation.fetch(:application_type)).to eq 'initial'
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/api/datastore/v1/searching/filter_by_case_type_spec.rb
+++ b/spec/api/datastore/v1/searching/filter_by_case_type_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'searches filter by case type' do
+  subject(:api_request) do
+    post '/api/v1/searches', params: { search: search, pagination: {} }
+  end
+
+  let(:records) { JSON.parse(response.body).fetch('records') }
+  let(:search) { {} }
+
+  before do
+    CrimeApplication.insert_all(
+      [
+        { submitted_application: { case_details: { case_type:  Types::CaseType['summary_only'] } } },
+        { submitted_application: { case_details: { case_type:  Types::CaseType['either_way'] } } },
+      ]
+    )
+
+    api_request
+  end
+
+  it 'defaults to returning all case types' do
+    expect(records.count).to be 2
+    expect(records.pluck('case_type').uniq).to match_array(%w[summary_only either_way])
+  end
+
+  describe 'filtering by "summary_only"' do
+    let(:search) { { case_type: ['summary_only'] } }
+
+    it 'returns only "summary_only" applications' do
+      expect(records.count).to be 1
+      expect(records.pluck('case_type').uniq).to eq(['summary_only'])
+    end
+  end
+
+  describe 'filtering by multiple case types' do
+    let(:search) { { case_type: %w[summary_only either_way] } }
+
+    it 'returns records with a case_type in case_types' do
+      expect(records.count).to be 2
+      expect(records.pluck('case_type').uniq).to match_array(%w[summary_only either_way])
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Adds application type and case type to search results. Also adds case_type as a virtual attribute to facilitate sorting by case type in the search table in review

## Link to relevant ticket
[CRIMAPP-282](https://dsdmoj.atlassian.net/browse/CRIMAPP-282)

## Notes for reviewer / how to test
Requires pulling down the review changes to test: https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/492

Instructions for testing in the review PR

[CRIMAPP-282]: https://dsdmoj.atlassian.net/browse/CRIMAPP-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ