### PR TITLE
Expose means passport on search results

### DIFF
--- a/app/api/datastore/entities/v1/search_result.rb
+++ b/app/api/datastore/entities/v1/search_result.rb
@@ -17,6 +17,7 @@ module Datastore
         expose :provider_name
         expose :application_type
         expose :case_type
+        expose :means_passport
 
         private
 
@@ -54,6 +55,10 @@ module Datastore
 
         def application_type
           object.submitted_application&.dig('application_type')
+        end
+
+        def means_passport
+          object.submitted_application&.dig('means_passport')
         end
       end
     end

--- a/spec/api/datastore/entities/v1/search_result_spec.rb
+++ b/spec/api/datastore/entities/v1/search_result_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
   let(:work_stream) { 'criminal_applications_team' }
   let(:case_type) { 'summary_only' }
   let(:application_type) { 'initial' }
+  let(:means_passport) { ['on_benefit_check'] }
 
   let(:submitted_application) do
     LaaCrimeSchemas.fixture(1.0) { |json| json.merge('parent_id' => parent_id) }
@@ -104,6 +105,10 @@ RSpec.describe Datastore::Entities::V1::SearchResult do
 
   it 'represents the application_type' do
     expect(representation.fetch(:application_type)).to eq 'initial'
+  end
+
+  it 'represents the means_passport' do
+    expect(representation.fetch(:means_passport)).to eq ['on_benefit_check']
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
## Description of change
Expose means_passport to allow Review to display in return reasons means column the means test as opposed to hard-coding 'passported
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-364
## Notes for reviewer / how to test
