### PR TITLE
Ensure maat application only inlcude attributes in the schema

### DIFF
--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -3,33 +3,39 @@ module Datastore
     module V1
       module MAAT
         class Application < BaseApplicationEntity
-          unexpose :ioj_passport,
-                   :interests_of_justice,
-                   :status,
-                   :parent_id,
-                   :created_at,
-                   :work_stream,
-                   :additional_information
+          unexpose(
+            :created_at,
+            :parent_id,
+            :work_stream,
+            :reviewed_at,
+            :status
+          )
 
-          expose :submitted_at, as: :declaration_signed_at
-          expose :ioj_bypass, proc: ->(_) { interests_of_justice.empty? }
-
+          expose :case_details
+          expose :client_details
           expose :date_stamp
+          expose :ioj_bypass
           expose :means_passport
           expose :provider_details
-          expose :client_details
-          expose :case_details
+          expose :submitted_at, as: :declaration_signed_at
 
           private
 
           def case_details
-            super.except(
-              'offences',
-              'codefendants',
-              # TODO: clarify with MAAT if they need the first court hearing details
-              'is_first_court_hearing',
-              'first_court_hearing_name'
-            )
+            super.slice(*%w[
+                          urn
+                          case_type
+                          appeal_maat_id
+                          appeal_lodged_date
+                          appeal_with_changes_details
+                          offence_class
+                          hearing_court_name
+                          hearing_date
+                        ])
+          end
+
+          def ioj_bypass
+            interests_of_justice.blank?
           end
         end
       end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -90,9 +90,8 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
 
   describe "conforms to the 'maat_application' schema" do
     let(:schema) do
-      JSON.parse(File.read(File.join(
-                             LaaCrimeSchemas.root, 'schemas', '1.0', 'maat_application.json'
-                           )))
+      schema_file_path = File.join(LaaCrimeSchemas.root, 'schemas', '1.0', 'maat_application.json')
+      JSON.parse(File.read(schema_file_path))
     end
 
     it 'exposes only the expected root properties' do
@@ -101,10 +100,24 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
       expect(representation.keys).to match_array(expected_root_properties)
     end
 
-    it 'exposes only the expected case_details properties' do
+    it 'exposes only the expected case_details root properties' do
       expected_case_details = schema.dig('properties', 'case_details', 'properties').keys
 
       expect(representation.fetch('case_details').keys).to match_array(expected_case_details)
+    end
+
+    it 'exposes only the expected client_details root properties' do
+      expected_case_details = schema.dig('properties', 'client_details', 'properties').keys
+
+      expect(representation.fetch('client_details').keys).to match_array(expected_case_details)
+    end
+
+    it 'exposes only the expected applicant root properties' do
+      expected_applicant_details = schema.dig(
+        'properties', 'client_details', 'properties', 'applicant', 'properties'
+      ).keys
+
+      expect(representation.dig('client_details', 'applicant').keys).to match_array(expected_applicant_details)
     end
   end
 end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe Datastore::Entities::V1::MAAT::Application do
+  subject(:representation) do
+    JSON.parse(described_class.represent(crime_application).to_json)
+  end
+
+  let(:crime_application) do
+    instance_double(
+      CrimeApplication,
+      id: SecureRandom.uuid,
+      status: Types::ApplicationStatus['submitted'],
+      submitted_at: 3.days.ago,
+      reviewed_at: nil,
+      returned_at: 3.days.ago - 1.hour,
+      return_details: { reason: nil, details: nil, returned_at: nil },
+      offence_class: Types::OffenceClass['C'],
+      work_stream: Types::WorkStreamType['criminal_applications_team'],
+      submitted_application: submitted_application
+    )
+  end
+
+  let(:submitted_application) do
+    LaaCrimeSchemas.fixture(1.0) { |json| json.merge('parent_id' => SecureRandom.uuid) }
+  end
+
+  it 'represents the provider details' do
+    expect(representation.fetch('provider_details')).to eq submitted_application.fetch('provider_details')
+  end
+
+  it 'represents the client details' do
+    expect(representation.fetch('client_details')).to eq submitted_application.fetch('client_details')
+  end
+
+  describe 'ioj_bypass' do
+    subject(:ioj_bypass) { representation.fetch('ioj_bypass') }
+
+    it { is_expected.to be false }
+
+    context 'when ioj are empty' do
+      let(:submitted_application) { super().merge('interests_of_justice' => []) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when ioj are blank' do
+      let(:submitted_application) { super().merge('interests_of_justice' => nil) }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  it 'represents the means passport details' do
+    expect(representation.fetch('means_passport')).to eq submitted_application.fetch('means_passport')
+  end
+
+  it 'represents the reference' do
+    expect(representation.fetch('reference')).to eq submitted_application.fetch('reference')
+  end
+
+  it 'represents the application type' do
+    expect(representation.fetch('application_type')).to eq submitted_application.fetch('application_type')
+  end
+
+  it 'represents the id' do
+    expect(representation.fetch('id')).to eq submitted_application.fetch('id')
+  end
+
+  it 'represents submitted_at' do
+    expect(representation.fetch('submitted_at')).to eq crime_application.submitted_at.iso8601(3)
+  end
+
+  it 'represents declaration_signed_at' do
+    expect(representation.fetch('declaration_signed_at')).to eq crime_application.submitted_at.iso8601(3)
+  end
+
+  it 'represents date_stamp' do
+    expect(representation.fetch('date_stamp')).to eq submitted_application.fetch('date_stamp')
+  end
+
+  describe 'case_details' do
+    subject(:case_details) { representation.fetch('case_details') }
+
+    it { is_expected.to be_a(Hash) }
+
+    it 'includes the overall offence class within the case details' do
+      expect(case_details.fetch('offence_class')).to eq('C')
+    end
+  end
+
+  describe "conforms to the 'maat_application' schema" do
+    let(:schema) do
+      JSON.parse(File.read(File.join(
+                             LaaCrimeSchemas.root, 'schemas', '1.0', 'maat_application.json'
+                           )))
+    end
+
+    it 'exposes only the expected root properties' do
+      expected_root_properties = schema['properties'].keys
+
+      expect(representation.keys).to match_array(expected_root_properties)
+    end
+
+    it 'exposes only the expected case_details properties' do
+      expected_case_details = schema.dig('properties', 'case_details', 'properties').keys
+
+      expect(representation.fetch('case_details').keys).to match_array(expected_case_details)
+    end
+  end
+end

--- a/spec/api/datastore/v1/applications/get_application_spec.rb
+++ b/spec/api/datastore/v1/applications/get_application_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'get application' do
       end
 
       it 'returned details satisfy with schema' do
-        expect(validator).to be_valid, validator.fully_validate
+        expect(validator).to be_valid, -> { validator.fully_validate }
       end
 
       context 'when post submission evidence application' do
@@ -53,7 +53,7 @@ RSpec.describe 'get application' do
         end
 
         it 'returned details satisfy with schema' do
-          expect(validator).to be_valid, validator.fully_validate
+          expect(validator).to be_valid, -> { validator.fully_validate }
         end
       end
     end

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -6,11 +6,14 @@ RSpec.describe 'get application ready for maat' do
 
     let(:application) do
       CrimeApplication.create(
-        submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read),
+        submitted_application: submitted_application,
         review_status: :ready_for_assessment
       )
     end
 
+    let(:submitted_application) do
+      JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
+    end
     let(:application_usn) { application.submitted_application['reference'] }
     let(:maat_application) { JSON.parse(response.body) }
 
@@ -20,53 +23,7 @@ RSpec.describe 'get application ready for maat' do
 
     context 'with a ready for assessment application' do
       before do
-        allow(Utils::OffenceClassCalculator).to receive(:new) {
-                                                  instance_double(Utils::OffenceClassCalculator,
-                                                                  offence_class: calculated_offence_class)
-                                                }
         api_request
-      end
-
-      let(:calculated_offence_class) { Types::OffenceClass.values.sample }
-
-      # rubocop:disable Layout/LineLength
-      let(:expected_case_details) do
-        {
-          'case_type' => application.submitted_application['case_details']['case_type'],
-          'appeal_maat_id' => application.submitted_application['case_details']['appeal_maat_id'],
-          'appeal_lodged_date' => application.submitted_application['case_details']['appeal_lodged_date'],
-          'appeal_with_changes_details' => application.submitted_application['case_details']['appeal_with_changes_details'],
-          'hearing_court_name' => application.submitted_application['case_details']['hearing_court_name'],
-          'hearing_date' => application.submitted_application['case_details']['hearing_date'],
-          'offence_class' => calculated_offence_class,
-          'urn' => application.submitted_application['case_details']['urn'],
-          'date_case_concluded' => application.submitted_application['case_details']['date_case_concluded'],
-          'has_case_concluded' => application.submitted_application['case_details']['has_case_concluded'],
-          'is_client_remanded' => application.submitted_application['case_details']['is_client_remanded'],
-          'date_client_remanded' => application.submitted_application['case_details']['date_client_remanded'],
-          'is_preorder_work_claimed' => application.submitted_application['case_details']['is_preorder_work_claimed'],
-          'preorder_work_date' => application.submitted_application['case_details']['preorder_work_date'],
-          'preorder_work_details' => application.submitted_application['case_details']['preorder_work_details']
-        }
-      end
-      # rubocop:enable Layout/LineLength
-
-      let(:expected_maat_application) do
-        {
-          'application_type' => application.submitted_application['application_type'],
-          'reference' => application.submitted_application['reference'],
-          'reviewed_at' => application.reviewed_at,
-          'client_details' => application.submitted_application['client_details'],
-          'provider_details' => application.submitted_application['provider_details'],
-          'submitted_at' => application.submitted_application['submitted_at'],
-          'declaration_signed_at' => application.submitted_application['submitted_at'],
-          'date_stamp' => application.submitted_application['date_stamp'],
-          'means_passport' => application.submitted_application['means_passport'],
-          'ioj_bypass' => application.submitted_application['interests_of_justice'].empty?,
-          'case_details' => expected_case_details,
-          'schema_version' => application.submitted_application['schema_version'],
-          'id' => application.id
-        }
       end
 
       it 'returns http status 200' do
@@ -78,15 +35,29 @@ RSpec.describe 'get application ready for maat' do
           LaaCrimeSchemas::Validator.new(response.body, version: 1.0, schema_name: 'maat_application')
         ).to be_valid
       end
+    end
 
-      it 'returns the required application details for maat integration' do
-        expect(maat_application).to match(expected_maat_application)
+    describe 'returning the calcuated offence class' do
+      let(:offence_class) { Types::OffenceClass.values.sample }
+
+      before do
+        allow(Utils::OffenceClassCalculator).to receive(:new).and_return(
+          instance_double(Utils::OffenceClassCalculator, offence_class:)
+        )
+        api_request
+      end
+
+      it 'is included in the case_details' do
+        expect(maat_application['case_details']['offence_class']).to eq(offence_class)
       end
     end
 
     context 'with a completed application' do
       before do
-        application.update!(review_status: :assessment_completed, reviewed_at: 1.week.ago)
+        application.update!(
+          review_status: :assessment_completed,
+          reviewed_at: DateTime.new(2022, 12, 1, 12, 28, 58.001)
+        )
         api_request
       end
 


### PR DESCRIPTION
## Description of change
A few superfluous attributes were added unnecessarily to the MAAT application JSON. This PR does the following:

1. Adds a spec to ensure that only attributes defined in the `maat_application` schema are present in the entity.
2. Adjusts extra details from the `crime_application` to be opt-in rather than opt-out, ensuring that adding new attributes to the entity is a deliberate choice.

In this process, the following attributes have been removed from the MAAT application:

From root:
- `reviewed_at`

From `case_details`:
- `date_case_concluded`
- `date_client_remanded`
- `has_case_concluded`
- `is_client_remanded`
- `is_preorder_work_claimed`
- `preorder_work_date`
- `preorder_work_details`

## Link to relevant ticket

## Notes for reviewer / how to test
Deploy to staging and confirm that MAAT integration works okay.
