### PR TITLE
[CRIMAPP-449] Redact additional information

### DIFF
--- a/app/services/redacting/redact.rb
+++ b/app/services/redacting/redact.rb
@@ -34,6 +34,8 @@ module Redacting
                     details.slice(*fields).compact_blank
                   when :array
                     details.map { |item| item.slice(*fields).compact_blank }
+                  when :string
+                    details
                   else
                     raise "unknown rule path type: #{type}"
                   end
@@ -71,6 +73,8 @@ module Redacting
     def redact(details)
       if details.is_a?(Array)
         details.map { |item| redact(item.dup) }
+      elsif details.is_a?(String)
+        REDACTED_KEYWORD
       else
         details.each_key { |key| details[key] = REDACTED_KEYWORD }
       end

--- a/app/services/redacting/rules.rb
+++ b/app/services/redacting/rules.rb
@@ -27,6 +27,10 @@ module Redacting
         redact: %w[s3_object_key filename],
         type: :array # [{}, {}, ...]
       },
+      'additional_information' => {
+        redact: :value,
+        type: :string
+      }
     }.freeze
 
     def self.pii_attributes

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -96,6 +96,18 @@ describe Redacting::Redact do
         )
       end
     end
+
+    context 'with additional information' do
+      let(:submitted_application) do
+        super().deep_merge('additional_information' => 'Additional information here')
+      end
+
+      let(:additional_information) { redacted_application['additional_information'] }
+
+      it 'redacts the expected attributes' do
+        expect(additional_information).to eq('__redacted__')
+      end
+    end
   end
 
   describe 'metadata attributes' do

--- a/spec/services/redacting/rules_spec.rb
+++ b/spec/services/redacting/rules_spec.rb
@@ -15,6 +15,7 @@ describe Redacting::Rules do
           case_details.codefendants
           interests_of_justice
           supporting_evidence
+          additional_information
         ]
       )
     end


### PR DESCRIPTION
## Description of change
Redacts `additional_information` text ahead of feature release

## Link to relevant ticket
[CRIMAPP-449](https://dsdmoj.atlassian.net/browse/CRIMAPP-449)

## Notes for reviewer / how to test

Submit an application with additional information. Open a datastore console and retrieve the submitted application and its redacted record. JSON for additional information should look similar to this:

```
"additional_information"=>"__redacted__"
``` 


[CRIMAPP-449]: https://dsdmoj.atlassian.net/browse/CRIMAPP-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ