### PR TITLE
Crimapp 453 change maat schema unemployed journey

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.37'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.38'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 92580fc4f29ea7fa3c4e27769e0fc1f87f271a07
-  ref: 92580fc4f29ea7fa3c4e27769e0fc1f87f271a07
+  revision: cecf7eb53143b63f550cf50d21d0d7bb49b5403f
+  tag: v1.0.38
   specs:
     laa-criminal-legal-aid-schemas (1.0.38)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 70fabbeea84179dae570a5efb0218ef3451cf775
-  tag: v1.0.37
+  revision: 92580fc4f29ea7fa3c4e27769e0fc1f87f271a07
+  ref: 92580fc4f29ea7fa3c4e27769e0fc1f87f271a07
   specs:
-    laa-criminal-legal-aid-schemas (1.0.37)
+    laa-criminal-legal-aid-schemas (1.0.38)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -23,7 +23,6 @@ module Datastore
             expose :outgoings_details
           end
 
-
           private
 
           def case_details
@@ -40,20 +39,20 @@ module Datastore
           end
 
           def income_details
-            means_details['income_details'].slice(*%w[
-              benefits
-              dependants
-              employment_type
-              employment_details
-              other_income
-            ])
+            means_details.fetch('income_details', nil)&.slice(*%w[
+                                                    benefits
+                                                    dependants
+                                                    employment_type
+                                                    employment_details
+                                                    other_income
+                                                  ])
           end
 
           def outgoings_details
-            means_details['outgoings_details'].slice(*%w[
-              outgoings
-              housing_payment_type
-            ])
+            means_details.fetch('outgoings_details', nil)&.slice(*%w[
+                                                       outgoings
+                                                       housing_payment_type
+                                                     ])
           end
 
           def ioj_bypass

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -18,6 +18,11 @@ module Datastore
           expose :means_passport
           expose :provider_details
           expose :submitted_at, as: :declaration_signed_at
+          expose :means_details do
+            expose :income_details
+            expose :outgoings_details
+          end
+
 
           private
 
@@ -32,6 +37,23 @@ module Datastore
                           hearing_court_name
                           hearing_date
                         ])
+          end
+
+          def income_details
+            means_details['income_details'].slice(*%w[
+              benefits
+              dependants
+              employment_type
+              employment_details
+              other_income
+            ])
+          end
+
+          def outgoings_details
+            means_details['outgoings_details'].slice(*%w[
+              outgoings
+              housing_payment_type
+            ])
           end
 
           def ioj_bypass

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -39,20 +39,20 @@ module Datastore
           end
 
           def income_details
-            means_details.fetch('income_details', nil)&.slice(*%w[
-                                                    benefits
-                                                    dependants
-                                                    employment_type
-                                                    employment_details
-                                                    other_income
-                                                  ])
+            means_details.fetch('income_details', nil)&.slice(%w[
+                                                                benefits
+                                                                dependants
+                                                                employment_type
+                                                                employment_details
+                                                                other_income
+                                                              ])
           end
 
           def outgoings_details
-            means_details.fetch('outgoings_details', nil)&.slice(*%w[
-                                                       outgoings
-                                                       housing_payment_type
-                                                     ])
+            means_details.fetch('outgoings_details', nil)&.slice(%w[
+                                                                   outgoings
+                                                                   housing_payment_type
+                                                                 ])
           end
 
           def ioj_bypass

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -94,6 +94,11 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
       JSON.parse(File.read(schema_file_path))
     end
 
+    let(:maat_means_schema) do
+      schema_file_path = File.join(LaaCrimeSchemas.root, 'schemas', '1.0', 'maat','means.json')
+      JSON.parse(File.read(schema_file_path))
+    end
+
     it 'exposes only the expected root properties' do
       expected_root_properties = schema['properties'].keys
 
@@ -121,11 +126,26 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
     end
 
     describe 'means details relevant to MAAT' do
-
       it 'exposes only the expected means details root properties' do
-        expected_means_details = ['income_details', 'outgoings_details']
+        expected_means_details = maat_means_schema.dig('properties').keys
 
-        expect(representation.dig('means_details').keys).to match_array(expected_means_details)
+        expect(representation['means_details'].keys).to match_array(expected_means_details)
+      end
+
+      it 'exposes only the expected income_details properties for applcation fixture' do
+        possible_income_details = maat_means_schema.dig('properties', 'income_details', 'properties').keys
+
+        fixture_properties = representation['means_details']['income_details'].keys
+
+        expect(possible_income_details).to include(*fixture_properties)
+      end
+
+      it 'exposes only the expected outgoings_details properties for application fixture' do
+        possible_outgoings_details = maat_means_schema.dig('properties', 'outgoings_details', 'properties').keys
+
+        fixture_properties = representation['means_details']['outgoings_details'].keys
+
+        expect(possible_outgoings_details).to include(*fixture_properties)
       end
     end
   end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -119,5 +119,14 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
 
       expect(representation.dig('client_details', 'applicant').keys).to match_array(expected_applicant_details)
     end
+
+    describe 'means details relevant to MAAT' do
+
+      it 'exposes only the expected means details root properties' do
+        expected_means_details = ['income_details', 'outgoings_details']
+
+        expect(representation.dig('means_details').keys).to match_array(expected_means_details)
+      end
+    end
   end
 end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
     end
 
     let(:maat_means_schema) do
-      schema_file_path = File.join(LaaCrimeSchemas.root, 'schemas', '1.0', 'maat','means.json')
+      schema_file_path = File.join(LaaCrimeSchemas.root, 'schemas', '1.0', 'maat', 'means.json')
       JSON.parse(File.read(schema_file_path))
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
 
     describe 'means details relevant to MAAT' do
       it 'exposes only the expected means details root properties' do
-        expected_means_details = maat_means_schema.dig('properties').keys
+        expected_means_details = maat_means_schema['properties'].keys
 
         expect(representation['means_details'].keys).to match_array(expected_means_details)
       end


### PR DESCRIPTION
## Description of change
Adds basic means details to the MAAT API

## Link to relevant ticket

## Notes for reviewer / how to test
This PR is contingent on https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/93 

If you want to test it before the merge then you can set schemas to the latest commit for PR 93 above like so:

```ruby
gem 'laa-criminal-legal-aid-schemas',
    # github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.38'
    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', ref: '92580fc4f29ea7fa3c4e27769e0fc1f87f271a07'
```

Probably best to get the schema merged first and then test this.

Steps to test locally
1. comment out the following lines in `app/api/datastore/root.rb`

```ruby
    auth :jwt
    use SimpleJwtAuth::Middleware::Grape::Authorisation
```

this will allow you to do a GET as if you were MAAT without worrying about auth.

2. Set all the feature flags to production mode, and do a regression where you submit and application, send it back, re-submit, and Mark it as ready for MAAT
3. Turn on the means assessment features, and submit an application with means info, send it back, re-submit and then mark it ready for MAAT
4. With postman or just your browser make a GET request to `/api/v1/maat/applications/:usn` where the USN is either the non-means case or the casaes with means info.
5. You should then see the JSON response - for the non-means tested application `means_details` should be empty.
6. For the means tested application you should only be possible to see the following nested keys:

```
- means_details
    - income_details
        - benefits
        - dependants
        - employment_type
        - employment_details
        - other_income
    - outgoings_details
        - outgoings
        - housing_payment_type 
```