### PR TITLE
Replace benefit_type none with nil for MAAT

### DIFF
--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -25,6 +25,12 @@ module Datastore
 
           private
 
+          def client_details
+            super['applicant']['benefit_type'] = nil if super['applicant']['benefit_type'] == 'none'
+
+            super
+          end
+
           def case_details
             super.slice(*%w[
                           urn

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -26,7 +26,7 @@ module Datastore
           private
 
           def client_details
-            super['applicant']['benefit_type'] = nil if super['applicant']['benefit_type'] == 'none'
+            super['applicant']['benefit_type'] = nil if super.dig('applicant', 'benefit_type') == 'none'
 
             super
           end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -78,6 +78,34 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
     expect(representation.fetch('date_stamp')).to eq submitted_application.fetch('date_stamp')
   end
 
+  describe 'client_details' do
+    subject(:client_details) { representation.fetch('client_details') }
+
+    it { is_expected.to be_a(Hash) }
+
+    context 'when benefit_type is not `none`' do
+      it 'does not modify the benefit_type' do
+        expect(client_details['applicant'].fetch('benefit_type')).to eq('universal_credit')
+      end
+    end
+
+    context 'when benefit_type is `none`' do
+      let(:submitted_application) do
+        LaaCrimeSchemas.fixture(1.0) do |json|
+          json.deep_merge(
+            'client_details' => {
+              'applicant' => { 'benefit_type' => 'none' }
+            }
+          )
+        end
+      end
+
+      it 'sets benefit_type to nil' do
+        expect(client_details['applicant'].fetch('benefit_type')).to be_nil
+      end
+    end
+  end
+
   describe 'case_details' do
     subject(:case_details) { representation.fetch('case_details') }
 


### PR DESCRIPTION
## Description of change
MAAT doesn't want to handle 'none' and nil for benefit_type, as they amount to the same thing. We don't want to store it as nil for us, as there is a difference to Apply and Review between the two values. This therefore was the best place to transform it.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-604
