### PR TITLE
Fix exposing means to MAAT endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-  github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.59'
-
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.59'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.59'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.60'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.57'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.58'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-
   revision: 9345af3d94e686f449cc3206d0a97a273a44a070
   tag: v1.0.59
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 9345af3d94e686f449cc3206d0a97a273a44a070
-  tag: v1.0.59
+  revision: 1d86152c9b835eb23abc58de4b66684e852bf91c
+  tag: v1.0.60
   specs:
-    laa-criminal-legal-aid-schemas (1.0.59)
+    laa-criminal-legal-aid-schemas (1.0.60)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 590c88db180c9ff62f1d3301f0597a0a15e931b2
-  tag: v1.0.57
+  revision: b700652b80aad9d1204976aaf0493283cde1cf8d
+  tag: v1.0.58
   specs:
-    laa-criminal-legal-aid-schemas (1.0.56)
+    laa-criminal-legal-aid-schemas (1.0.58)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -25,6 +25,11 @@ module Datastore
 
           private
 
+          ARRAYS_WITH_DETAILS = %w[
+            income_payments
+            income_benefits
+          ].freeze
+
           def client_details
             super['applicant']['benefit_type'] = nil if super.dig('applicant', 'benefit_type') == 'none'
 
@@ -44,29 +49,47 @@ module Datastore
                         ])
           end
 
+          # rubocop:disable Lint/RedundantSplatExpansion
           def income_details
-            means_details.fetch('income_details', nil)&.slice(%w[
-                                                                benefits
-                                                                dependants
-                                                                employment_type
-                                                                employment_details
-                                                                other_income
-                                                              ])
+            income = means_details.fetch('income_details', nil)&.slice(*%w[
+                                                                         income_payments
+                                                                         income_benefits
+                                                                         dependants
+                                                                         employment_type
+                                                                         employment_details
+                                                                       ])
+
+            extract_details(income)
+            income
           end
 
           def outgoings_details
-            means_details.fetch('outgoings_details', nil)&.slice(%w[
+            means_details.fetch('outgoings_details', nil)&.slice(*%w[
                                                                    outgoings
-                                                                   housing_payment_type
-                                                                   income_tax_rate_above_threshold
-                                                                   outgoings_more_than_income
-                                                                   how_manage
-                                                                   pays_council_tax
                                                                  ])
           end
+          # rubocop:enable Lint/RedundantSplatExpansion
 
           def ioj_bypass
             interests_of_justice.blank?
+          end
+
+          def extract_details(section) # rubocop:disable Metrics/MethodLength
+            section.map do |element|
+              if ARRAYS_WITH_DETAILS.include?(element.first)
+                new_element = [element.first]
+
+                element.last.map do |payment|
+                  payment['details'] = payment.dig('metadata', 'details') unless payment['metadata'] == {}
+                  payment.delete('metadata')
+                  payment
+                end
+
+                new_element << element.last
+              else
+                element
+              end
+            end
           end
         end
       end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -59,7 +59,7 @@ module Datastore
                                                                          employment_details
                                                                        ])
 
-            extract_details(income)
+            extract_details(income) if income
             income
           end
 
@@ -75,7 +75,7 @@ module Datastore
           end
 
           def extract_details(section) # rubocop:disable Metrics/MethodLength
-            section.map do |element|
+            section&.map do |element|
               if ARRAYS_WITH_DETAILS.include?(element.first)
                 new_element = [element.first]
 

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -50,7 +50,7 @@ module Datastore
           end
 
           # Maintain `nil` return value if there are no payments
-          def income_details
+          def income_details # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
             income = means_details.fetch('income_details', nil)&.slice(
               'income_payments',
               'income_benefits',
@@ -63,7 +63,9 @@ module Datastore
               next unless PAYMENT_TYPES_WITH_DETAILS.include?(type)
 
               list.each do |item|
+                next unless item['metadata'].is_a?(Hash)
                 next if item['metadata'] == {}
+
                 item['details'] = item.dig('metadata', 'details')
               end
             end

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -49,26 +49,22 @@ module Datastore
                         ])
           end
 
-          # rubocop:disable Lint/RedundantSplatExpansion
           def income_details
-            income = means_details.fetch('income_details', nil)&.slice(*%w[
-                                                                         income_payments
-                                                                         income_benefits
-                                                                         dependants
-                                                                         employment_type
-                                                                         employment_details
-                                                                       ])
+            income = means_details.fetch('income_details', nil)&.slice(
+              'income_payments',
+              'income_benefits',
+              'dependants',
+              'employment_type',
+              'employment_details'
+            )
 
             extract_details(income) if income
             income
           end
 
           def outgoings_details
-            means_details.fetch('outgoings_details', nil)&.slice(*%w[
-                                                                   outgoings
-                                                                 ])
+            means_details.fetch('outgoings_details', nil)&.slice('outgoings')
           end
-          # rubocop:enable Lint/RedundantSplatExpansion
 
           def ioj_bypass
             interests_of_justice.blank?

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -186,8 +186,6 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         expect(representation.dig('means_details', 'income_details',
                                   'income_benefits').last.keys).to match_array(expected_income_benefits)
         expect(representation.dig('means_details', 'income_details', 'income_benefits').last.keys).to include('details')
-        expect(representation.dig('means_details', 'income_details',
-                                  'income_benefits').last.keys).not_to include('metadata')
       end
     end
   end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -176,5 +176,19 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         expect(possible_outgoings_details).to include(*fixture_properties)
       end
     end
+
+    describe 'extract_details' do
+      it 'exposes details not metadata for income_benefits' do
+        expected_income_benefits = maat_means_schema.dig(
+          'properties', 'income_details', 'properties', 'income_benefits', 'items', 'properties'
+        ).keys
+
+        expect(representation.dig('means_details', 'income_details',
+                                  'income_benefits').last.keys).to match_array(expected_income_benefits)
+        expect(representation.dig('means_details', 'income_details', 'income_benefits').last.keys).to include('details')
+        expect(representation.dig('means_details', 'income_details',
+                                  'income_benefits').last.keys).not_to include('metadata')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Fix exposing means to MAAT endpoint

Add splat to extract strings from arrays

Updates key names for income_benefits and income_payments

Crime Core devs requested that details were pulled out of metadata as the nesting caused trouble with the way their mappings build models and they only need details and nothing else

Add null safety checks to allow for applications with no means details to still be fetched correctly. 

## Notes for reviewer / how to test

Looks like rubocop removed this splat after we'd tested it last time, so MAAT endpoint lost access to these exposed values. 

Keys and values have changed over time and have broken tests that match schema with fixtures

Steps to test locally

1. comment out the following lines in app/api/datastore/root.rb

    `auth :jwt`
    `use SimpleJwtAuth::Middleware::Grape::Authorisation`
this will allow you to do a GET as if you were MAAT without worrying about auth.


2. Set all the feature flags to production mode, and do a regression where you submit and application, send it back, re-submit, and Mark it as ready for MAAT
3. Turn on the means assessment features, and submit an application with means info, send it back, re-submit and then mark it ready for MAAT
4. With postman or just your browser make a GET request to /api/v1/maat/applications/:usn where the USN is either the non-means case or the casaes with means info.
5. You should then see the JSON response - for the non-means tested application means_details should be empty.
6. For the means tested application you should only be possible to see the following nested keys:
