### PR TITLE
[CRIMAPP-618] Expose capital details for MAAT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.0.60'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', ref: '4bf901171a85d4fbd8eea36273565daba185970d'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', ref: '4bf901171a85d4fbd8eea36273565daba185970d'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', ref: 'v1.0.61'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 4bf901171a85d4fbd8eea36273565daba185970d
-  ref: 4bf901171a85d4fbd8eea36273565daba185970d
+  revision: a467691dae5d9605a7111ba975ca25461ae4f849
+  ref: v1.0.61
   specs:
     laa-criminal-legal-aid-schemas (1.0.61)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 1d86152c9b835eb23abc58de4b66684e852bf91c
-  tag: v1.0.60
+  revision: 4bf901171a85d4fbd8eea36273565daba185970d
+  ref: 4bf901171a85d4fbd8eea36273565daba185970d
   specs:
-    laa-criminal-legal-aid-schemas (1.0.60)
+    laa-criminal-legal-aid-schemas (1.0.61)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -21,6 +21,7 @@ module Datastore
           expose :means_details do
             expose :income_details
             expose :outgoings_details
+            expose :capital_details
           end
 
           private
@@ -73,6 +74,17 @@ module Datastore
 
           def outgoings_details
             means_details.fetch('outgoings_details', nil)&.slice('outgoings')
+          end
+
+          def capital_details
+            means_details.fetch('capital_details', nil)&.slice(
+              'premium_bonds_total_value',
+              'trust_fund_amount_held',
+              'savings',
+              'national_savings_certificates',
+              'investments',
+              'properties'
+            )
           end
 
           def ioj_bypass


### PR DESCRIPTION
## Description of change
Expose capital details for MAAT
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-618
## Notes for reviewer / how to test

1. comment out the following lines in app/api/datastore/root.rb
```
auth :jwt
    use SimpleJwtAuth::Middleware::Grape::Authorisation
```

this will allow you to do a GET as if you were MAAT without worrying about auth.

2. Set all the feature flags to production mode, and do a regression where you submit and application, send it back, re-submit, and Mark it as ready for MAAT
3. Turn on the means assessment features, and submit an application with means info, send it back, re-submit and then mark it ready for MAAT
4. With postman or just your browser make a GET request to /api/v1/maat/applications/:usn where the USN is either the non-means case or the case with means info.
5. You should then see the JSON response - for the non-means tested application means_details should be empty.
For the means tested application you should only be possible to see the following nested keys:
- means_details
    - income_details
        - benefits
        - dependants
        - employment_type
        - employment_details
        - other_income
    - outgoings_details
        - outgoings
    - capital_details
        - premium_bonds_total_value
        - trust_fund_amount_held
        - savings
        - national_savings_certificates
        - investments
        - properties