### PR TITLE
Update schema to v1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.1.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.1.3'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 22152ee0b6e21034f451dfeb962d29b44ac8e0f0
-  tag: v1.1.1
+  revision: 2e077060151f63fddd728c896032e6da3179ab2c
+  tag: v1.1.3
   specs:
-    laa-criminal-legal-aid-schemas (1.1.1)
+    laa-criminal-legal-aid-schemas (1.1.3)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
`ownership_type` was previously a required field in the schema which was breaking in progress applications 
Fixes sentry error: https://mojdt.slack.com/archives/C056U956ESH/p1716307797032809

## Link to relevant ticket

## Notes for reviewer / how to test
