### PR TITLE
Update to schema 1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'aws-sdk-s3'
 gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
-    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.1.1'
+    github: 'ministryofjustice/laa-criminal-legal-aid-schemas', tag: 'v1.1.3'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 22152ee0b6e21034f451dfeb962d29b44ac8e0f0
-  tag: v1.1.1
+  revision: 2e077060151f63fddd728c896032e6da3179ab2c
+  tag: v1.1.3
   specs:
-    laa-criminal-legal-aid-schemas (1.1.1)
+    laa-criminal-legal-aid-schemas (1.1.3)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/lib/types.rb
+++ b/app/lib/types.rb
@@ -6,4 +6,13 @@ module Types
     post_submission_evidence
   ].freeze
   ApplicationType = String.enum(*APPLICATION_TYPES)
+
+  APPLICATION_STATUSES = %w[
+    submitted
+    returned
+    superseded
+  ].freeze
+
+  # The datastore does not have in_progress applications
+  Types::ApplicationStatus = String.enum(*APPLICATION_STATUSES)
 end


### PR DESCRIPTION
## Description of change

NOTE: Schema structs now support in-progress applications. The datastore does not include these, so the schema type `Types::ApplicationStatus` is overridden to exclude in-progress applications.


## Link to relevant ticket

## Notes for reviewer / how to test
