### PR TITLE
CRIMAPP-1140 : Apply - Maat intergration: Employed Income amount not being injected

### DIFF
--- a/app/api/datastore/entities/v1/maat/application.rb
+++ b/app/api/datastore/entities/v1/maat/application.rb
@@ -61,7 +61,7 @@ module Datastore
               'income_benefits',
               'dependants',
               'employment_type',
-              'employment_details'
+              'employment_income_payments'
             )
 
             income&.each do |type, list|


### PR DESCRIPTION
## Description of change

- Removed "employment_details"
- Added "employment_income_payments"

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1140

## Notes for reviewer / how to test
