### PR TITLE
[CRIMAPP-1195] Calculate non means queue with `is_means_tested` attribute

### DIFF
--- a/app/services/utils/work_stream_calculator.rb
+++ b/app/services/utils/work_stream_calculator.rb
@@ -33,10 +33,7 @@ module Utils
     end
 
     def non_means_tested?
-      return false if means_passport.blank?
-
-      # TODO: find out if this is the correct way to identify non_means_tested
-      means_passport.include?(Types::MeansPassportType['on_not_means_tested'])
+      is_means_tested == 'no'
     end
 
     def self_employed?
@@ -60,6 +57,6 @@ module Utils
       means_details&.income_details
     end
 
-    delegate :case_details, :means_details, :means_passport, to: :application
+    delegate :case_details, :means_details, :is_means_tested, to: :application
   end
 end

--- a/spec/services/utils/work_stream_calculator_spec.rb
+++ b/spec/services/utils/work_stream_calculator_spec.rb
@@ -6,16 +6,16 @@ describe Utils::WorkStreamCalculator do
 
   let(:application) do
     instance_double(
-      LaaCrimeSchemas::Structs::CrimeApplication, case_details:, means_details:, means_passport:
+      LaaCrimeSchemas::Structs::CrimeApplication, case_details:, means_details:, is_means_tested:
     )
   end
 
   let(:first_court_name) { nil }
   let(:hearing_court_name) { 'Cardiff Crown Court' }
   let(:case_details) { instance_double(LaaCrimeSchemas::Structs::CaseDetails) }
-  let(:means_passport) { [] }
   let(:means_details) { instance_double(LaaCrimeSchemas::Structs::MeansDetails, income_details:) }
   let(:income_details) { LaaCrimeSchemas::Structs::IncomeDetails.new }
+  let(:is_means_tested) { 'yes' }
 
   before do
     allow(case_details).to receive_messages(
@@ -141,20 +141,18 @@ describe Utils::WorkStreamCalculator do
         calculator.work_stream == LaaCrimeSchemas::Types::WorkStreamType['non_means_tested']
       end
 
-      context 'when there is no means passport' do
-        let(:means_passport) { nil }
+      context 'when `is_means_tested` is nil' do
+        let(:is_means_tested) { nil }
 
         it { is_expected.to be false }
       end
 
-      context 'when the application is passported an other type' do
-        let(:means_passport) { ['on_something_else'] }
-
+      context 'when the application is not means tested' do
         it { is_expected.to be false }
       end
 
-      context 'when the application is passported on_not_means_tested' do
-        let(:means_passport) { ['on_not_means_tested'] }
+      context 'when the application is means tested' do
+        let(:is_means_tested) { 'no' }
 
         it { is_expected.to be true }
       end


### PR DESCRIPTION
## Description of change
Refactors work stream calculator to calculate non means queue with the `is_means_tested` attribute rather than the means passport value. This is to prevent inaccuracies in the event that an application is resubmitted and the means passport value has not been updated

## Link to relevant ticket
[CRIMAPP-1195](https://dsdmoj.atlassian.net/browse/CRIMAPP-1195)

## Notes for reviewer / how to test
Follow steps in ticket

[CRIMAPP-1195]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ