### PR TITLE
CRIMAPP-963: Expose 'How does your client manage with no income?' attributes to MAAT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.1.33'
+    tag: 'v1.2.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 93db97e8a056eb3f46a6e7e6c6863f4ea3133694
-  tag: v1.1.33
+  revision: 1ae303e88d01904ab1439dea45c60dd644a20f7b
+  tag: v1.2.1
   specs:
-    laa-criminal-legal-aid-schemas (1.1.33)
+    laa-criminal-legal-aid-schemas (1.2.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -10,6 +10,8 @@ module Datastore
           expose :dependants, expose_nil: false
           expose :employment_type
           expose :employment_income_payments, expose_nil: false
+          expose :manage_without_income, expose_nil: false
+          expose :manage_other_details, expose_nil: false
 
           def income_payments
             object['income_payments'].reject { |p| p['payment_type'] == 'employment' }

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -227,6 +227,83 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         expect(validator).to be_valid, -> { validator.fully_validate }
       end
     end
+
+    context 'with attribute `manage_without_income` in `income_details`' do
+      context 'when manage_without_income is valid' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working'],
+                  'manage_without_income' => 'living_on_streets'
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+      end
+
+      context 'when manage_without_income is invalid' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working'],
+                  'manage_without_income' => 'invalid_text'
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).not_to be_valid, -> { validator.fully_validate }
+        end
+      end
+
+      context 'when manage_without_income is nil' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working'],
+                  'manage_without_income' => nil
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+      end
+
+      context 'when manage_without_income is missing' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working']
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+      end
+    end
   end
 
   describe "conforms to the 'maat_application' schema" do
@@ -267,7 +344,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         expect(representation['means_details'].keys).to match_array(expected_means_details)
       end
 
-      it 'exposes only the expected income_details properties for applcation fixture' do
+      it 'exposes only the expected income_details properties for application fixture' do
         possible_income_details = maat_means_schema.dig('properties', 'income_details', 'properties').keys
 
         fixture_properties = representation['means_details']['income_details'].keys


### PR DESCRIPTION
## Description of change
Expose 'income_details' attributes to MAAT

- manage_without_income
- manage_other_details
 
## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-963

## Notes for reviewer / how to test
