### PR TITLE
CRIMAPP-1117 - MAAT integration - 'partner_trust_fund' does not inject into MAAT

### DIFF
--- a/app/api/datastore/entities/v1/maat/capital_details.rb
+++ b/app/api/datastore/entities/v1/maat/capital_details.rb
@@ -7,6 +7,7 @@ module Datastore
 
           expose :premium_bonds_total_value
           expose :trust_fund_amount_held
+          expose :partner_trust_fund_amount_held
           expose :savings, expose_nil: false
           expose :national_savings_certificates, expose_nil: false
           expose :investments, expose_nil: false

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -304,6 +304,46 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         end
       end
     end
+
+    context 'with `partner_trust_fund_amount` in `capital_details`' do
+      context 'when partner_trust_fund_amount is present' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => nil,
+                'outgoings_details' => nil,
+                'capital_details' => { 'partner_trust_fund_amount_held' => partner_trust_fund_amount_held }
+              }
+            )
+          end
+        end
+
+        context 'when valid' do
+          let(:partner_trust_fund_amount_held) { 1000 }
+
+          it 'is valid' do
+            expect(validator).to be_valid, -> { validator.fully_validate }
+          end
+        end
+
+        context 'when invalid' do
+          let(:partner_trust_fund_amount_held) { 'should_be_a_number' }
+
+          it 'is valid' do
+            expect(validator).not_to be_valid, -> { validator.fully_validate }
+          end
+        end
+      end
+
+      context 'when partner_trust_fund_amount is not present' do
+        let(:partner_trust_fund_amount_held) { nil }
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+      end
+    end
   end
 
   describe "conforms to the 'maat_application' schema" do

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -352,6 +352,14 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         expect(possible_income_details).to include(*fixture_properties)
       end
 
+      it 'exposes only the expected capital_details properties for application fixture' do
+        possible_capital_details = maat_means_schema.dig('properties', 'capital_details', 'properties').keys
+
+        fixture_properties = representation['means_details']['capital_details'].keys
+
+        expect(possible_capital_details).to include(*fixture_properties)
+      end
+
       it 'exposes only the expected outgoings_details properties for application fixture' do
         possible_outgoings_details = maat_means_schema.dig('properties', 'outgoings_details', 'properties').keys
 


### PR DESCRIPTION
## Description of change
Expose 'capital_details' attributes to MAAT
- partner_trust_fund_amount_held

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1117

## Notes for reviewer / how to test

> [!NOTE]  
> We will be sending both attributes 'trust_fund_amount_held' and 'partner_trust_fund_amount_held'. MAAT will sum it up and display in the relevant column

<img width="1280" alt="8f6c121e-0383-45fe-875c-b45c05e24d28" src="https://github.com/user-attachments/assets/505d19c0-aab1-456f-905c-d0c87cae99c8">

