### PR TITLE
[CRIMAPP-1246, CRIMAPP-1247] Update cat2 stream calculation logic

### DIFF
--- a/app/services/utils/work_stream_calculator.rb
+++ b/app/services/utils/work_stream_calculator.rb
@@ -61,7 +61,7 @@ module Utils
       means_details&.income_details
     end
 
-    def restraint_or_freezing_order?
+    def restraint_or_freezing_order? # rubocop:disable Metrics/CyclomaticComplexity
       return false unless income_details || means_details&.capital_details
 
       income_details&.has_frozen_income_or_assets == 'yes' ||

--- a/app/services/utils/work_stream_calculator.rb
+++ b/app/services/utils/work_stream_calculator.rb
@@ -19,7 +19,7 @@ module Utils
     def calculated_work_stream
       return 'extradition' if extradition_case?
       return 'non_means_tested' if non_means_tested?
-      return 'criminal_applications_team_2' if self_employed? || self_assessment_tax_bill?
+      return 'criminal_applications_team_2' if cat_2_case?
 
       'criminal_applications_team'
     end
@@ -34,6 +34,10 @@ module Utils
 
     def non_means_tested?
       is_means_tested == 'no'
+    end
+
+    def cat_2_case?
+      self_employed? || self_assessment_tax_bill? || restraint_or_freezing_order? || rental_income?
     end
 
     def self_employed?
@@ -55,6 +59,19 @@ module Utils
 
     def income_details
       means_details&.income_details
+    end
+
+    def restraint_or_freezing_order?
+      return false unless income_details || means_details&.capital_details
+
+      income_details&.has_frozen_income_or_assets == 'yes' ||
+        means_details&.capital_details&.has_frozen_income_or_assets == 'yes'
+    end
+
+    def rental_income?
+      return false unless income_details
+
+      income_details.income_payments.find { |p| p.payment_type == 'rent' }
     end
 
     delegate :case_details, :means_details, :is_means_tested, to: :application


### PR DESCRIPTION
## Description of change
Applications will now be referred to the criminal applications team 2 queue if there is a:
- a restraint or freezing order
- a rental income payment

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1246
https://dsdmoj.atlassian.net/browse/CRIMAPP-1247

## Notes for reviewer / how to test
Pull down this branch and submit the following applications on apply:

- An application with a restraint or freezing order answered in the income section
- An application with a restraint or freezing order answered in the capital section
- An application with an income payment with the payment type 'rent'

These applications should appear in the cat2 queue in review 