### PR TITLE
Crimapp-1119 Fix annualisation

### DIFF
--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -17,13 +17,13 @@ module Datastore
 
           def income_payments
             Utils::MAAT::OtherIncomePaymentCalculator.new(
-              payments: object['income_payments'].map(&:dup),
+              payments: object['income_payments'].map(&:deep_dup),
             ).call
           end
 
           def income_benefits
             Utils::MAAT::OtherIncomeBenefitCalculator.new(
-              payments: object['income_benefits'].map(&:dup),
+              payments: object['income_benefits'].map(&:deep_dup),
             ).call
           end
         end

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -22,7 +22,7 @@ module Datastore
           end
 
           def income_benefits
-            ::Utils::MAAT::OtherIncomeBenefitCalculator.new(
+            Utils::MAAT::OtherIncomeBenefitCalculator.new(
               payments: object['income_benefits'],
             ).call
           end

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -17,13 +17,13 @@ module Datastore
 
           def income_payments
             Utils::MAAT::OtherIncomePaymentCalculator.new(
-              payments: object['income_payments'],
+              payments: object['income_payments'].map(&:dup),
             ).call
           end
 
           def income_benefits
             Utils::MAAT::OtherIncomeBenefitCalculator.new(
-              payments: object['income_benefits'],
+              payments: object['income_benefits'].map(&:dup),
             ).call
           end
         end

--- a/app/services/utils/maat/other_income_base.rb
+++ b/app/services/utils/maat/other_income_base.rb
@@ -49,6 +49,7 @@ module Utils
       end
 
       def create_other_payment(ownership_type)
+        income_payment_notes = income_payment_notes(ownership_type)
         payments.push(
           {
             'payment_type' => OTHER,
@@ -56,7 +57,7 @@ module Utils
             'frequency' => Utils::AnnualizedAmountCalculator::PAYMENT_FREQUENCY_TYPE[:annual],
             'ownership_type' => ownership_type,
             'metadata' => {
-              'details' => income_payment_notes((ownership_type))
+              'details' => income_payment_notes
             }
           }
         )

--- a/app/services/utils/maat/other_income_base.rb
+++ b/app/services/utils/maat/other_income_base.rb
@@ -49,7 +49,6 @@ module Utils
       end
 
       def create_other_payment(ownership_type)
-        income_payment_notes = income_payment_notes(ownership_type)
         payments.push(
           {
             'payment_type' => OTHER,
@@ -57,7 +56,7 @@ module Utils
             'frequency' => Utils::AnnualizedAmountCalculator::PAYMENT_FREQUENCY_TYPE[:annual],
             'ownership_type' => ownership_type,
             'metadata' => {
-              'details' => income_payment_notes
+              'details' => income_payment_notes(ownership_type)
             }
           }
         )

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1083,7 +1083,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                     },
                     {
                       'amount' => 5000,
-                     'metadata' =>
+                      'metadata' =>
                        {
                          'details' => 'Details of the other applicant payment'
                        },
@@ -1123,10 +1123,9 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                     },
                     {
                       'amount' => 70_000,
-                     'metadata' =>
-                       {
-                         'details' => 'Details of the other income benefit'
-                       },
+                      'metadata' => {
+                        'details' => 'Details of the other income benefit'
+                      },
                      'frequency' => 'month',
                      'payment_type' => 'other',
                      'ownership_type' => 'applicant'
@@ -1140,10 +1139,9 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                     },
                     {
                       'amount' => 80_000,
-                     'metadata' =>
-                       {
-                         'details' => 'Details of the other income benefit'
-                       },
+                      'metadata' => {
+                        'details' => 'Details of the other income benefit'
+                      },
                      'frequency' => 'month',
                      'payment_type' => 'other',
                      'ownership_type' => 'partner'

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1020,6 +1020,249 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
         end
       end
     end
+
+    context 'with `income_payments` and `income_benefits`' do
+      context 'when `income_payments` and `income_benefits` are missing' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working'],
+                  'income_payments' => [],
+                  'income_benefits' => []
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+
+        it 'returns empty income_payments' do
+          income_payments = representation.dig('means_details', 'income_details', 'income_payments')
+          expect(income_payments).to be_empty
+        end
+
+        it 'returns empty income_benefits' do
+          income_benefits = representation.dig('means_details', 'income_details', 'income_benefits')
+          expect(income_benefits).to be_empty
+        end
+      end
+
+      context 'when `income_payments` and `income_benefits` are present' do
+        let(:submitted_application) do
+          LaaCrimeSchemas.fixture(1.0) do |json|
+            json.merge(
+              'means_details' => {
+                'income_details' => {
+                  'employment_type' => ['not_working'],
+                  'income_payments' => [
+                    {
+                      'amount' => 100_000,
+                      'metadata' => {},
+                      'frequency' => 'annual',
+                      'payment_type' => 'state_pension',
+                      'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 10_000,
+                      'metadata' => {},
+                      'frequency' => 'fortnight',
+                      'payment_type' => 'student_loan_grant',
+                      'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 10_000,
+                      'metadata' => {},
+                      'frequency' => 'four_weeks',
+                      'payment_type' => 'board_from_family',
+                      'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 5000,
+                     'metadata' =>
+                       {
+                         'details' => 'Details of the other applicant payment'
+                       },
+                     'frequency' => 'week',
+                     'payment_type' => 'other',
+                     'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 40_000,
+                      'metadata' => {},
+                      'frequency' => 'fortnight',
+                      'payment_type' => 'state_pension',
+                      'ownership_type' => 'partner'
+                    },
+                    {
+                      'amount' => 10_000,
+                      'metadata' => {},
+                      'frequency' => 'week',
+                      'payment_type' => 'interest_investment',
+                      'ownership_type' => 'partner'
+                    },
+                    {
+                      'amount' => 6000,
+                      'metadata' => {},
+                      'frequency' => 'week',
+                      'payment_type' => 'from_friends_relatives',
+                      'ownership_type' => 'partner'
+                    }
+                  ],
+                  'income_benefits' => [
+                    {
+                      'amount' => 50_000,
+                      'metadata' => {},
+                      'frequency' => 'fortnight',
+                      'payment_type' => 'jsa',
+                      'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 70_000,
+                     'metadata' =>
+                       {
+                         'details' => 'Details of the other income benefit'
+                       },
+                     'frequency' => 'month',
+                     'payment_type' => 'other',
+                     'ownership_type' => 'applicant'
+                    },
+                    {
+                      'amount' => 5000,
+                      'metadata' => {},
+                      'frequency' => 'fortnight',
+                      'payment_type' => 'child',
+                      'ownership_type' => 'partner'
+                    },
+                    {
+                      'amount' => 80_000,
+                     'metadata' =>
+                       {
+                         'details' => 'Details of the other income benefit'
+                       },
+                     'frequency' => 'month',
+                     'payment_type' => 'other',
+                     'ownership_type' => 'partner'
+                    }
+                  ]
+                }
+              }
+            )
+          end
+        end
+
+        it 'is valid' do
+          expect(validator).to be_valid, -> { validator.fully_validate }
+        end
+
+        it 'return updated income_payments' do
+          income_payments = representation.dig('means_details', 'income_details', 'income_payments')
+
+          expect(income_payments).to contain_exactly(
+            {
+              'amount' => 100_000,
+              'metadata' => {},
+              'frequency' => 'annual',
+              'payment_type' => 'state_pension',
+              'ownership_type' => 'applicant'
+            },
+            {
+              'amount' => 650_000,
+              'metadata' =>
+                {
+                  'details' => <<~HEREDOC
+                    Details of the other applicant payment
+                    applicant: student_loan_grant:10000:fortnight, board_from_family:10000:four_weeks, other:5000:week
+                  HEREDOC
+                },
+              'frequency' => 'annual',
+              'payment_type' => 'other',
+              'ownership_type' => 'applicant',
+              'details' => <<~HEREDOC
+                Details of the other applicant payment
+                applicant: student_loan_grant:10000:fortnight, board_from_family:10000:four_weeks, other:5000:week
+              HEREDOC
+            },
+            {
+              'amount' => 40_000,
+              'metadata' => {},
+              'frequency' => 'fortnight',
+              'payment_type' => 'state_pension',
+              'ownership_type' => 'partner'
+            },
+            {
+              'amount' => 10_000,
+              'metadata' => {},
+              'frequency' => 'week',
+              'payment_type' => 'interest_investment',
+              'ownership_type' => 'partner'
+            },
+            {
+              'amount' => 312_000,
+              'metadata' => {
+                'details' => 'partner: from_friends_relatives:6000:week'
+              },
+              'frequency' => 'annual',
+              'payment_type' => 'other',
+              'ownership_type' => 'partner',
+              'details' => 'partner: from_friends_relatives:6000:week'
+            }
+          )
+        end
+
+        it 'return updated income_benefits' do
+          income_benefits = representation.dig('means_details', 'income_details', 'income_benefits')
+
+          expect(income_benefits).to contain_exactly(
+            {
+              'amount' => 2_140_000,
+              'metadata' =>
+                {
+                  'details' =>  <<~HEREDOC
+                    Details of the other income benefit
+                    applicant: jsa:50000:fortnight, other:70000:month
+                  HEREDOC
+                },
+              'frequency' => 'annual',
+              'payment_type' => 'other',
+              'ownership_type' => 'applicant',
+              'details' => <<~HEREDOC
+                Details of the other income benefit
+                applicant: jsa:50000:fortnight, other:70000:month
+              HEREDOC
+            },
+            {
+              'amount' => 5000,
+              'metadata' => {},
+              'frequency' => 'fortnight',
+              'payment_type' => 'child',
+              'ownership_type' => 'partner'
+            },
+            {
+              'amount' => 960_000,
+              'metadata' =>
+                {
+                  'details' => <<~HEREDOC
+                    Details of the other income benefit
+                    partner: other:80000:month
+                  HEREDOC
+                },
+              'frequency' => 'annual',
+              'payment_type' => 'other',
+              'ownership_type' => 'partner',
+              'details' => <<~HEREDOC
+                Details of the other income benefit
+                partner: other:80000:month
+              HEREDOC
+            }
+          )
+        end
+      end
+    end
     # rubocop:enable RSpec/ExampleLength
   end
 


### PR DESCRIPTION
## Description of change
- Avoid updating original objects(`income_payments` and `income_benefits`) when passed to `Utils::MAAT::OtherIncomePaymentCalculator` because annualised amount will be updated always by number of times `.call` is invoked
- Instead, create a copy of `income_payments` and `income_benefits` and pass as a parameter to  `Utils::MAAT::OtherIncomePaymentCalculator` 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1119

## Notes for reviewer / how to test
