### PR TITLE
[CRIMAPP-1300] Route armed forces to CAT2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.6'
+    tag: 'v1.2.7'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a118338056bb1d8de1b6ed52e58247caa21e9bbb
-  tag: v1.2.6
+  revision: bb45aafb5f1233fbb025c9939454110a6800b576
+  tag: v1.2.7
   specs:
-    laa-criminal-legal-aid-schemas (1.2.6)
+    laa-criminal-legal-aid-schemas (1.2.7)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/services/utils/work_stream_calculator.rb
+++ b/app/services/utils/work_stream_calculator.rb
@@ -37,7 +37,7 @@ module Utils
     end
 
     def cat_2_case?
-      self_employed? || self_assessment_tax_bill? || restraint_or_freezing_order? || rental_income?
+      self_employed? || self_assessment_tax_bill? || restraint_or_freezing_order? || rental_income? || in_armed_forces?
     end
 
     def self_employed?
@@ -72,6 +72,12 @@ module Utils
       return false unless income_details
 
       income_details.income_payments.find { |p| p.payment_type == 'rent' }
+    end
+
+    def in_armed_forces?
+      return false unless income_details
+
+      income_details.client_in_armed_forces == 'yes' || income_details.partner_in_armed_forces == 'yes'
     end
 
     delegate :case_details, :means_details, :is_means_tested, to: :application

--- a/spec/services/utils/work_stream_calculator_spec.rb
+++ b/spec/services/utils/work_stream_calculator_spec.rb
@@ -191,6 +191,26 @@ describe Utils::WorkStreamCalculator do
 
         it { is_expected.to be false }
       end
+
+      context 'when the client is in the armed forces' do
+        let(:income_details) do
+          LaaCrimeSchemas::Structs::IncomeDetails.new(
+            client_in_armed_forces: 'yes'
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'when the partner is in the armed forces' do
+        let(:income_details) do
+          LaaCrimeSchemas::Structs::IncomeDetails.new(
+            partner_in_armed_forces: 'yes'
+          )
+        end
+
+        it { is_expected.to be true }
+      end
     end
 
     describe 'Non-means tested determination' do


### PR DESCRIPTION
## Description of change
Applications where the client and/or partner is in the armed forces are routed to CAT2.

## Link to relevant ticket
[CRIMAPP-1300](https://dsdmoj.atlassian.net/browse/CRIMAPP-1300)

## Notes for reviewer / how to test


[CRIMAPP-1300]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ