### PR TITLE
CRIMAPP-345 fix pod crash loop

### DIFF
--- a/app/services/status/healthcheck.rb
+++ b/app/services/status/healthcheck.rb
@@ -21,7 +21,7 @@ module Status
       end
 
       def database_connected?
-        ActiveRecord::Base.connection.active?
+        ActiveRecord::Base.connection.execute('SELECT 1').present?
       rescue StandardError => e
         Rails.logger.error(e)
         Sentry.capture_exception(e)

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -48,14 +48,14 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /health
+            path: /ping.json
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 30
+          initialDelaySeconds: 5
           periodSeconds: 10
         envFrom:
           - configMapRef:

--- a/config/kubernetes/staging/deployment.tpl
+++ b/config/kubernetes/staging/deployment.tpl
@@ -44,18 +44,30 @@ spec:
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 15
-          periodSeconds: 10
+          initialDelaySeconds: 5
+          periodSeconds: 5
         livenessProbe:
           httpGet:
-            path: /ping.json
+            path: /ping
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Ssl
                 value: "on"
-          initialDelaySeconds: 5
+          failureThreshold: 1
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+            httpHeaders:
+              - name: X-Forwarded-Proto
+                value: https
+              - name: X-Forwarded-Ssl
+                value: "on"
+          initialDelaySeconds: 1
+          failureThreshold: 20
           periodSeconds: 10
         envFrom:
           - configMapRef:


### PR DESCRIPTION
## Description of change

For testing on staging:
- use ping for Liveness probe
- user start probe
- user simple query for healthcheck

## Link to relevant ticket

[CRIMAPP-345](https://dsdmoj.atlassian.net/browse/CRIMAPP-345)

## Notes for reviewer / how to test

### NB Change is for testing on staging only

The liveness probe was previously using the same endpoint as the readiness probe, which included a database connection check. We suspect that when the liveness probe takes too long due to database latency, it triggers unnecessary container restarts.

This update removes the database check from the liveness probe and also removes liveness initial delay, which should prevent restarts caused by temporary database connection issues.


[CRIMAPP-345]: https://dsdmoj.atlassian.net/browse/CRIMAPP-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ