### PR TITLE
CRIMAPP-1318  Dividends from a trust fund - considered as ‘income’ and needs to be added to the total value of 'Other Income' in MAAT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.7'
+    tag: 'v1.2.8'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: bb45aafb5f1233fbb025c9939454110a6800b576
-  tag: v1.2.7
+  revision: 87d39ebd1b2a50fb05325d1d82b3698e31dc32db
+  tag: v1.2.8
   specs:
-    laa-criminal-legal-aid-schemas (1.2.7)
+    laa-criminal-legal-aid-schemas (1.2.8)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/capital_details.rb
+++ b/app/api/datastore/entities/v1/maat/capital_details.rb
@@ -7,7 +7,9 @@ module Datastore
 
           expose :premium_bonds_total_value
           expose :trust_fund_amount_held
+          expose :trust_fund_yearly_dividend
           expose :partner_trust_fund_amount_held
+          expose :partner_trust_fund_yearly_dividend
           expose :savings, expose_nil: false
           expose :national_savings_certificates, expose_nil: false
           expose :investments, expose_nil: false

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -12,18 +12,18 @@ module Datastore
           expose :employment_income_payments, expose_nil: false
           expose :manage_without_income, expose_nil: false
           expose :manage_other_details, expose_nil: false
-          expose :capital_attributes, expose_nil: false
+          expose :dividends, expose_nil: false
 
           private
 
           # rubocop:disable Metrics/AbcSize
           def income_payments
             dividends = []
-            if object.dig('capital_attributes', 'trust_fund_yearly_dividend')
-              dividends << dividend(object['capital_attributes']['trust_fund_yearly_dividend'], 'applicant')
+            if object.dig('dividends', 'trust_fund_yearly_dividend')
+              dividends << dividend(object['dividends']['trust_fund_yearly_dividend'], 'applicant')
             end
-            if object.dig('capital_attributes', 'partner_trust_fund_yearly_dividend')
-              dividends << dividend(object['capital_attributes']['partner_trust_fund_yearly_dividend'], 'partner')
+            if object.dig('dividends', 'partner_trust_fund_yearly_dividend')
+              dividends << dividend(object['dividends']['partner_trust_fund_yearly_dividend'], 'partner')
             end
 
             Utils::MAAT::OtherIncomePaymentCalculator.new(

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -37,7 +37,7 @@ module Datastore
               'amount' => amount,
               'frequency' =>	'annual',
               'metadata' =>	{},
-              'payment_type' =>	'trust_fund_yearly_dividend',
+              'payment_type' =>	'trust_fund_dividend',
               'ownership_type' =>	ownership_type,
             }
           end

--- a/app/api/datastore/entities/v1/maat/income_details.rb
+++ b/app/api/datastore/entities/v1/maat/income_details.rb
@@ -19,10 +19,10 @@ module Datastore
           # rubocop:disable Metrics/AbcSize
           def income_payments
             dividends = []
-            if object['capital_attributes'] && object['capital_attributes']['trust_fund_yearly_dividend']
+            if object.dig('capital_attributes', 'trust_fund_yearly_dividend')
               dividends << dividend(object['capital_attributes']['trust_fund_yearly_dividend'], 'applicant')
             end
-            if object['capital_attributes'] && object['capital_attributes']['partner_trust_fund_yearly_dividend']
+            if object.dig('capital_attributes', 'partner_trust_fund_yearly_dividend')
               dividends << dividend(object['capital_attributes']['partner_trust_fund_yearly_dividend'], 'partner')
             end
 
@@ -35,9 +35,9 @@ module Datastore
           def dividend(amount, ownership_type)
             {
               'amount' => amount,
-              'frequency' =>	'annual',
+              'frequency' =>	Utils::AnnualizedAmountCalculator::PAYMENT_FREQUENCY_TYPE[:annual],
               'metadata' =>	{},
-              'payment_type' =>	'trust_fund_dividend',
+              'payment_type' =>	Utils::MAAT::OtherIncomePaymentCalculator::DIVIDEND,
               'ownership_type' =>	ownership_type,
             }
           end

--- a/app/api/datastore/entities/v1/maat/means_details.rb
+++ b/app/api/datastore/entities/v1/maat/means_details.rb
@@ -8,6 +8,23 @@ module Datastore
           expose :income_details, using: IncomeDetails, expose_nil: false
           expose :outgoings_details, using: OutgoingsDetails, expose_nil: false
           expose :capital_details, using: CapitalDetails, expose_nil: false
+
+          private
+
+          def income_details
+            if object['capital_details'].present?
+              object['income_details'].merge!('capital_attributes' => capital_attributes)
+            else
+              object['income_details']
+            end
+          end
+
+          def capital_attributes
+            {
+              'trust_fund_yearly_dividend' => object['capital_details']['trust_fund_yearly_dividend'],
+              'partner_trust_fund_yearly_dividend' => object['capital_details']['partner_trust_fund_yearly_dividend']
+            }
+          end
         end
       end
     end

--- a/app/api/datastore/entities/v1/maat/means_details.rb
+++ b/app/api/datastore/entities/v1/maat/means_details.rb
@@ -12,17 +12,23 @@ module Datastore
           private
 
           def income_details
+            # Dividends are considered as income payments. To calculate the total 'Other Income', 2 capital_details
+            # attributes 'trust_fund_yearly_dividend' and 'partner_trust_fund_yearly_dividend'
+            # needs to be passed to income_details object and added to the total value of 'Other Income' in MAAT
+
             if object['capital_details'].present?
-              object['income_details'].merge!('capital_attributes' => capital_attributes)
+              object['income_details'].merge!('dividends' => dividends)
             else
               object['income_details']
             end
           end
 
-          def capital_attributes
+          def dividends
             {
-              'trust_fund_yearly_dividend' => object['capital_details']['trust_fund_yearly_dividend'],
-              'partner_trust_fund_yearly_dividend' => object['capital_details']['partner_trust_fund_yearly_dividend']
+              'trust_fund_yearly_dividend' => object.dig('capital_details',
+                                                         'trust_fund_yearly_dividend'),
+              'partner_trust_fund_yearly_dividend' => object.dig('capital_details',
+                                                                 'partner_trust_fund_yearly_dividend')
             }
           end
         end

--- a/app/services/utils/maat/other_income_payment_calculator.rb
+++ b/app/services/utils/maat/other_income_payment_calculator.rb
@@ -13,8 +13,13 @@ module Utils
         other
       ].freeze
 
+      DIVIDENDS = %w[
+        trust_fund_yearly_dividend
+        partner_trust_fund_yearly_dividend
+      ].freeze
+
       def payment_types
-        OTHER_INCOME_PAYMENT_TYPES
+        OTHER_INCOME_PAYMENT_TYPES + DIVIDENDS
       end
     end
   end

--- a/app/services/utils/maat/other_income_payment_calculator.rb
+++ b/app/services/utils/maat/other_income_payment_calculator.rb
@@ -14,8 +14,7 @@ module Utils
       ].freeze
 
       DIVIDENDS = %w[
-        trust_fund_yearly_dividend
-        partner_trust_fund_yearly_dividend
+        trust_fund_dividend
       ].freeze
 
       def payment_types

--- a/app/services/utils/maat/other_income_payment_calculator.rb
+++ b/app/services/utils/maat/other_income_payment_calculator.rb
@@ -13,12 +13,10 @@ module Utils
         other
       ].freeze
 
-      DIVIDENDS = %w[
-        trust_fund_dividend
-      ].freeze
+      DIVIDEND = 'trust_fund_dividend'.freeze
 
       def payment_types
-        OTHER_INCOME_PAYMENT_TYPES + DIVIDENDS
+        OTHER_INCOME_PAYMENT_TYPES + [DIVIDEND]
       end
     end
   end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1146,9 +1146,13 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                      'payment_type' => 'other',
                      'ownership_type' => 'partner'
                     }
-                  ]
+                  ],
+                  'capital_attributes' => {
+                    'trust_fund_yearly_dividend' => 12_550,
+                    'partner_trust_fund_yearly_dividend' => 10_000
+                  },
                 }
-              }
+              },
             )
           end
         end
@@ -1169,12 +1173,12 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
               'ownership_type' => 'applicant'
             },
             {
-              'amount' => 650_000,
+              'amount' => 662_550,
               'metadata' =>
                 {
                   'details' => <<~HEREDOC
                     Details of the other applicant payment
-                    Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week
+                    Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund yearly dividend:£125.50/annual
                   HEREDOC
                 },
               'frequency' => 'annual',
@@ -1182,7 +1186,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
               'ownership_type' => 'applicant',
               'details' => <<~HEREDOC
                 Details of the other applicant payment
-                Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week
+                Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund yearly dividend:£125.50/annual
               HEREDOC
             },
             {
@@ -1200,14 +1204,14 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
               'ownership_type' => 'partner'
             },
             {
-              'amount' => 312_000,
+              'amount' => 322_000,
               'metadata' => {
-                'details' => 'Partner: From friends relatives:£60.00/week'
+                'details' => 'Partner: From friends relatives:£60.00/week, Trust fund yearly dividend:£100.00/annual'
               },
               'frequency' => 'annual',
               'payment_type' => 'other',
               'ownership_type' => 'partner',
-              'details' => 'Partner: From friends relatives:£60.00/week'
+              'details' => 'Partner: From friends relatives:£60.00/week, Trust fund yearly dividend:£100.00/annual'
             }
           )
         end

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1147,7 +1147,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                      'ownership_type' => 'partner'
                     }
                   ],
-                  'capital_attributes' => {
+                  'dividends' => {
                     'trust_fund_yearly_dividend' => 12_550,
                     'partner_trust_fund_yearly_dividend' => 10_000
                   },

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -1178,7 +1178,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
                 {
                   'details' => <<~HEREDOC
                     Details of the other applicant payment
-                    Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund yearly dividend:£125.50/annual
+                    Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund dividend:£125.50/annual
                   HEREDOC
                 },
               'frequency' => 'annual',
@@ -1186,7 +1186,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
               'ownership_type' => 'applicant',
               'details' => <<~HEREDOC
                 Details of the other applicant payment
-                Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund yearly dividend:£125.50/annual
+                Applicant: Student loan grant:£100.00/fortnight, Board from family:£100.00/four_weeks, Other:£50.00/week, Trust fund dividend:£125.50/annual
               HEREDOC
             },
             {
@@ -1206,12 +1206,12 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
             {
               'amount' => 322_000,
               'metadata' => {
-                'details' => 'Partner: From friends relatives:£60.00/week, Trust fund yearly dividend:£100.00/annual'
+                'details' => 'Partner: From friends relatives:£60.00/week, Trust fund dividend:£100.00/annual'
               },
               'frequency' => 'annual',
               'payment_type' => 'other',
               'ownership_type' => 'partner',
-              'details' => 'Partner: From friends relatives:£60.00/week, Trust fund yearly dividend:£100.00/annual'
+              'details' => 'Partner: From friends relatives:£60.00/week, Trust fund dividend:£100.00/annual'
             }
           )
         end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -66,8 +66,7 @@ describe Redacting::Redact do
           'has_arc' => nil,
           'has_benefit_evidence' => 'no',
           'has_nino' => 'yes',
-          'will_enter_nino' => nil,
-          'arc' => nil
+          'will_enter_nino' => nil
         })
       end
     end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -66,7 +66,8 @@ describe Redacting::Redact do
           'has_arc' => nil,
           'has_benefit_evidence' => 'no',
           'has_nino' => 'yes',
-          'will_enter_nino' => nil
+          'will_enter_nino' => nil,
+          'arc' => nil
         })
       end
     end


### PR DESCRIPTION
## Description of change
- Expose `trust_fund_yearly_dividend` and `partner_trust_fund_yearly_dividend` attributes to MAAT API
- Trust fund dividend attributes (`trust_fund_yearly_dividend`, `partner_trust_fund_yearly_dividend`) belongs to `capital_details` object. To add trust funds to 'other_incomes' we need to pass these attributes to `income_details` object.
- Create additional attribute `dividends` to hold `trust_fund_yearly_dividend` and  `partner_trust_fund_yearly_dividend`
- Merge `dividends` with `income_details` object to calculate and add to total value of 'Other Income' in MAAT

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1318

## Notes for reviewer / how to test
> [!NOTE]   
> Specs are failing because of old schema version

> [!IMPORTANT]  
> TODO: Update schema version after approval: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas/pull/204
