### PR TITLE
CRIMAPP-1288 Appeal to crown court applications not injecting to MAAT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.2.8'
+    ref: '5494df2f77498db52af2309658e7dd2e27890727'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: 'c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a'
+    tag: 'v1.3.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '5494df2f77498db52af2309658e7dd2e27890727'
+    ref: '15c624dd24d7b71b645f654cf9740ceb6c4ffc9a'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: '15c624dd24d7b71b645f654cf9740ceb6c4ffc9a'
+    ref: 'c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 5494df2f77498db52af2309658e7dd2e27890727
-  ref: 5494df2f77498db52af2309658e7dd2e27890727
+  revision: 15c624dd24d7b71b645f654cf9740ceb6c4ffc9a
+  ref: 15c624dd24d7b71b645f654cf9740ceb6c4ffc9a
   specs:
-    laa-criminal-legal-aid-schemas (1.2.8)
+    laa-criminal-legal-aid-schemas (1.2.9)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 15c624dd24d7b71b645f654cf9740ceb6c4ffc9a
-  ref: 15c624dd24d7b71b645f654cf9740ceb6c4ffc9a
+  revision: c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a
+  ref: c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a
   specs:
     laa-criminal-legal-aid-schemas (1.2.9)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 87d39ebd1b2a50fb05325d1d82b3698e31dc32db
-  tag: v1.2.8
+  revision: 5494df2f77498db52af2309658e7dd2e27890727
+  ref: 5494df2f77498db52af2309658e7dd2e27890727
   specs:
     laa-criminal-legal-aid-schemas (1.2.8)
       dry-schema (~> 1.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a
-  ref: c6a32a117e8e62f6bb32c1dc777585c2df7a4c5a
+  revision: c60b8e76073222f1fcdd1c444a40130069f3c1cf
+  tag: v1.3.0
   specs:
-    laa-criminal-legal-aid-schemas (1.2.9)
+    laa-criminal-legal-aid-schemas (1.3.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/entities/v1/maat/case_details.rb
+++ b/app/api/datastore/entities/v1/maat/case_details.rb
@@ -8,6 +8,7 @@ module Datastore
           expose :urn
           expose :case_type, expose_nil: false
           expose :appeal_maat_id
+          expose :appeal_usn
           expose :appeal_lodged_date
           expose :appeal_with_changes_details
           expose :offence_class

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
     context 'when correspondence_address_type is not given' do
       let(:submitted_application) do
         LaaCrimeSchemas.fixture(1.0) do |json|
-          json.deep_merge('client_details' => { 'applicant' => {'correspondence_address_type' => nil} })
+          json.deep_merge('client_details' => { 'applicant' => { 'correspondence_address_type' => nil } })
         end
       end
 

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -192,6 +192,18 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
       end
     end
 
+    context 'when correspondence_address_type is not given' do
+      let(:submitted_application) do
+        LaaCrimeSchemas.fixture(1.0) do |json|
+          json.deep_merge('client_details' => { 'applicant' => {'correspondence_address_type' => nil} })
+        end
+      end
+
+      it 'is valid' do
+        expect(validator).to be_valid, -> { validator.fully_validate }
+      end
+    end
+
     context 'when means details are not given' do
       let(:submitted_application) do
         LaaCrimeSchemas.fixture(1.0) do |json|


### PR DESCRIPTION
## Description of change

- Validation error occurs when correspondence_address_type is not present. So we need to make it optional as   `correspondence_address_type` is not required for 'Appeal to crown court' applications
- Exposing  :appeal_usn attribute (may be required for MAAT)

![image (7)](https://github.com/user-attachments/assets/4cdf5a41-98b0-4091-a143-6f4ebdfc13e1)


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1288

## Sentry error
https://ministryofjustice.sentry.io/issues/5635408008/?environment=staging&project=4507142468468736&referrer=project-issue-stream&statsPeriod=1h

## Notes for reviewer / how to test

> [!IMPORTANT]  
> TODO: Update schema version once approved
