### PR TITLE
CRIMAPP-1288 Appeal to crown court applications not injecting to maat with missing hearing date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    ref: 'bb3ed9ddb13cd559ae125a9a33739b80a0ede401'
+    tag: 'v1.3.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.3.0'
+    ref: 'bb3ed9ddb13cd559ae125a9a33739b80a0ede401'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: c60b8e76073222f1fcdd1c444a40130069f3c1cf
-  tag: v1.3.0
+  revision: bb3ed9ddb13cd559ae125a9a33739b80a0ede401
+  ref: bb3ed9ddb13cd559ae125a9a33739b80a0ede401
   specs:
-    laa-criminal-legal-aid-schemas (1.3.0)
+    laa-criminal-legal-aid-schemas (1.3.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: bb3ed9ddb13cd559ae125a9a33739b80a0ede401
-  ref: bb3ed9ddb13cd559ae125a9a33739b80a0ede401
+  revision: 3f5f820720e34b22de8a026a12501d3efb4626ba
+  tag: v1.3.1
   specs:
     laa-criminal-legal-aid-schemas (1.3.1)
       dry-schema (~> 1.13)

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -204,6 +204,18 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
       end
     end
 
+    context 'when case_details hearing_date is not given' do
+      let(:submitted_application) do
+        LaaCrimeSchemas.fixture(1.0) do |json|
+          json.deep_merge('case_details' => { 'hearing_date' => nil })
+        end
+      end
+
+      it 'is valid' do
+        expect(validator).to be_valid, -> { validator.fully_validate }
+      end
+    end
+
     context 'when means details are not given' do
       let(:submitted_application) do
         LaaCrimeSchemas.fixture(1.0) do |json|


### PR DESCRIPTION
## Description of change

Validation error occurs when `#/case_details/hearing_date` is not present. So we need to make it optional as **hearing_date** is not required for **A change in financial circumstances** > **Appeal to crown court applications**

<img width="833" alt="affc3dc0-3d56-4bf5-9993-38dbc4adab0c" src="https://github.com/user-attachments/assets/d17123c1-fa43-47ec-bd2c-e850cb0582e5">


## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1288

## Notes for reviewer / how to test
Staging Application: 10002637
