### PR TITLE
[CRIMAPP-1333] Add reference to submission event data

### DIFF
--- a/app/services/events/submission.rb
+++ b/app/services/events/submission.rb
@@ -10,7 +10,8 @@ module Events
         submitted_at: crime_application.submitted_at,
         parent_id: crime_application.submitted_application['parent_id'],
         work_stream: crime_application.work_stream,
-        application_type: crime_application.application_type
+        application_type: crime_application.application_type,
+        reference: crime_application.reference
       }
     end
   end

--- a/spec/services/events/submission_spec.rb
+++ b/spec/services/events/submission_spec.rb
@@ -20,6 +20,7 @@ describe Events::Submission do
                     submitted_at: DateTime.parse('2023-02-27'),
                     parent_id: '9a123b',
                     work_stream: 'extradition',
-                    application_type: 'initial'
+                    application_type: 'initial',
+                    reference: 673_209,
                   }
 end


### PR DESCRIPTION
## Description of change

Adds reference( aka 'usn') to the sns message body.
 
## Link to relevant ticket


## Notes for reviewer / how to test

The submission history event stream is based on the reference (usn). Adding reference to this event, allows them to be linked without an additional request to the data store or loading the review aggregate.

(see also: https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/708 for CrimeReview changes)
