### PR TITLE
Bump laa-criminal-legal-aid-schemas to v1.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.3.1'
+    tag: 'v1.3.3'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3f5f820720e34b22de8a026a12501d3efb4626ba
-  tag: v1.3.1
+  revision: 28e036bd3e8b60bc8563b8d4045b548029cf59b1
+  tag: v1.3.3
   specs:
-    laa-criminal-legal-aid-schemas (1.3.1)
+    laa-criminal-legal-aid-schemas (1.3.3)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)


### PR DESCRIPTION
## Description of change
Bump laa-criminal-legal-aid-schemas to v1.3.3

## Link to relevant ticket
[CRIMAPP-825](https://dsdmoj.atlassian.net/browse/CRIMAPP-825)


[CRIMAPP-825]: https://dsdmoj.atlassian.net/browse/CRIMAPP-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ