### PR TITLE
[CRIMAPP-1400] Add Saving and Investment truncation

### DIFF
--- a/app/api/datastore/entities/v1/maat/capital_details.rb
+++ b/app/api/datastore/entities/v1/maat/capital_details.rb
@@ -10,9 +10,9 @@ module Datastore
           expose :trust_fund_yearly_dividend
           expose :partner_trust_fund_amount_held
           expose :partner_trust_fund_yearly_dividend
-          expose :savings, expose_nil: false
+          expose :savings, using: Saving, expose_nil: false
           expose :national_savings_certificates, expose_nil: false
-          expose :investments, expose_nil: false
+          expose :investments, using: Investment, expose_nil: false
           expose :properties, using: Property, expose_nil: false
         end
       end

--- a/app/api/datastore/entities/v1/maat/investment.rb
+++ b/app/api/datastore/entities/v1/maat/investment.rb
@@ -1,0 +1,22 @@
+module Datastore
+  module Entities
+    module V1
+      module MAAT
+        class Investment < Grape::Entity
+          include Transformer::MAAT
+
+          self.hash_access = :to_s
+
+          expose :investment_type, expose_nil: false
+          expose :description, expose_nil: false
+          expose :value, expose_nil: false
+          expose :ownership_type, expose_nil: false
+
+          def description
+            transform!('description', rule: 'investment')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/api/datastore/entities/v1/maat/saving.rb
+++ b/app/api/datastore/entities/v1/maat/saving.rb
@@ -1,0 +1,31 @@
+module Datastore
+  module Entities
+    module V1
+      module MAAT
+        class Saving < Grape::Entity
+          include Transformer::MAAT
+
+          self.hash_access = :to_s
+
+          expose :saving_type, expose_nil: false
+          expose :provider_name, expose_nil: false
+          expose :account_balance, expose_nil: false
+          expose :sort_code, expose_nil: false
+          expose :account_number, expose_nil: false
+          expose :is_overdrawn, expose_nil: false
+          expose :are_wages_paid_into_account, expose_nil: false
+          expose :are_partners_wages_paid_into_account, expose_nil: false
+          expose :ownership_type, expose_nil: false
+
+          def provider_name
+            transform!('provider_name', rule: 'saving')
+          end
+
+          def sort_code
+            transform!('sort_code', rule: 'saving')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/transformer/maat.rb
+++ b/app/lib/transformer/maat.rb
@@ -56,6 +56,13 @@ module Transformer
       'payment' => {
         'details' => 1000,
       },
+      'investment' => {
+        'description' => 250,
+      },
+      'saving' => {
+        'provider_name' => 50,
+        'sort_code' => 30,
+      },
     }.freeze
 
     # Assumes module is being used by a Grape::Entity or a Hash.


### PR DESCRIPTION
## Description of change
Truncates sort_code/provider_name in savings, and details in investments

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1400
## Notes for reviewer / how to test
In Apply create an application if possible with really long investment details > 250 characters. For savings if possible very long provider_name > 50 chars and sort-code that is > 20 chars.