### PR TITLE
[CRIMAPP-1398] Add missing decision attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.4.0'
+    tag: 'v1.4.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: a2b69c10443a70370bd618a98a59379decf44f4c
-  tag: v1.4.0
+  revision: 355ebc430e935a91c4339432d90116bf7c938ea0
+  tag: v1.4.1
   specs:
-    laa-criminal-legal-aid-schemas (1.4.0)
+    laa-criminal-legal-aid-schemas (1.4.1)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/app/api/datastore/v1/reviewing.rb
+++ b/app/api/datastore/v1/reviewing.rb
@@ -33,7 +33,11 @@ module Datastore
         params do
           requires :application_id, type: String, desc: 'Crime Application UUID'
           optional :decisions, type: [JSON] do
+            optional :reference, type: Integer
+            optional :maat_id, type: Integer
+            optional :case_id, type: String
             requires :interests_of_justice, type: JSON
+            optional :means, type: JSON
             requires :funding_decision, type: String
             optional :comment, type: String
           end

--- a/app/services/operations/complete_application.rb
+++ b/app/services/operations/complete_application.rb
@@ -3,6 +3,7 @@ module Operations
     def initialize(application_id:, decisions:)
       @application = CrimeApplication.find(application_id)
       @decisions = decisions
+      validate!
     end
 
     def call # rubocop:disable Metrics/AbcSize
@@ -21,6 +22,14 @@ module Operations
     end
 
     private
+
+    def validate!
+      schema_validator = LaaCrimeSchemas::Validator.new(@decisions, version: 1.0, schema_name: 'general/decision',
+list: true)
+      return if schema_validator.valid?
+
+      raise LaaCrimeSchemas::Errors::ValidationError, schema_validator.fully_validate
+    end
 
     attr_reader :application, :decisions
   end

--- a/db/migrate/20241101173540_add_case_id_to_decisions.rb
+++ b/db/migrate/20241101173540_add_case_id_to_decisions.rb
@@ -1,0 +1,5 @@
+class AddCaseIdToDecisions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :decisions, :case_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_22_160814) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_01_173540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_22_160814) do
     t.string "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "case_id"
     t.index ["crime_application_id"], name: "index_decisions_on_crime_application_id"
   end
 

--- a/spec/api/datastore/v1/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/complete_application_spec.rb
@@ -35,45 +35,110 @@ RSpec.describe 'complete application' do
         put("/api/v1/applications/#{application.id}/complete", params: { decisions: })
       end
 
-      let(:decisions) do
-        [
+      context 'when the decisions are invalid' do
+        let(:decisions) do
+          [
+            {
+              'reference' => 1234,
+              'maat_id' => 5678,
+              'case_id' => '123123123',
+              'interests_of_justice' => nil,
+              'means' => nil,
+              'funding_decision' => nil,
+              'comment' => 'test comment'
+            }.as_json,
+            {
+              'reference' => nil,
+              'maat_id' => nil,
+              'case_id' => '123123123',
+              'interests_of_justice' => {
+                'result' => 'pass',
+                'assessed_by' => 'Kory liam'
+              },
+              'means' => nil,
+              'funding_decision' => 'granted',
+              'comment' => 'test comment'
+            }.as_json
+          ]
+        end
+
+        it 'does not update the application' do
+          expect { api_request }
+            .to(
+              not_change { application.reload.review_status }
+              .and(not_change { application.reload.reviewed_at })
+            )
+        end
+
+        it 'returns 400' do
+          api_request
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns error information' do
+          api_request
+          expect(response.body).to include(
+            "The property '#/0/funding_decision' of type null did not match the following type: string in schema",
+            "The property '#/1/interests_of_justice' did not contain a required property of 'assessed_on'"
+          )
+        end
+      end
+
+      context 'when the decisions are valid' do
+        let(:decisions) do
+          [
+            {
+              'reference' => 1234,
+              'maat_id' => 5678,
+              'case_id' => '123123123',
+              'interests_of_justice' => interests_of_justice,
+              'means' => means,
+              'funding_decision' => 'granted',
+              'comment' => 'test comment'
+            }.as_json
+          ]
+        end
+
+        let(:interests_of_justice) do
           {
-            'reference' => 1234,
-            'maat_id' => nil,
-            'interests_of_justice' => interests_of_justice,
-            'means' => nil,
-            'funding_decision' => 'granted',
-            'comment' => 'test comment'
+            'result' => 'pass',
+            'details' => 'decision details',
+            'assessed_by' => 'Grace Nolan',
+            'assessed_on' => '2024-10-01 00:00:00'
           }
-        ].to_json
-      end
+        end
 
-      let(:interests_of_justice) do
-        {
-          'result' => 'pass',
-          'details' => 'decision details',
-          'assessed_by' => 'Grace Nolan',
-          'assessed_on' => '2024-10-01 00:00:00'
-        }
-      end
+        let(:means) do
+          {
+            'result' => 'fail',
+            'details' => 'means details',
+            'assessed_by' => 'Kory Liam',
+            'assessed_on' => '2024-11-01 00:00:00'
+          }
+        end
 
-      it 'marks the application as complete' do
-        expect { api_request }.to change { application.reload.review_status }
-          .from('application_received').to('assessment_completed')
-      end
+        it 'marks the application as complete' do
+          expect { api_request }.to change { application.reload.review_status }
+            .from('application_received').to('assessment_completed')
+        end
 
-      it 'records reviewed_at' do
-        expect { api_request }.to change { application.reload.reviewed_at }
-          .from(nil)
-      end
+        it 'records reviewed_at' do
+          expect { api_request }.to change { application.reload.reviewed_at }
+            .from(nil)
+        end
 
-      it 'persists the decisions' do
-        api_request
-        decisions = application.reload.decisions
-        expect(decisions.size).to eq(1)
-        expect(decisions.first.interests_of_justice).to eq(interests_of_justice)
-        expect(decisions.first.funding_decision).to eq('granted')
-        expect(decisions.first.comment).to eq('test comment')
+        it 'persists the decisions' do # rubocop:disable RSpec/MultipleExpectations
+          api_request
+          decisions = application.reload.decisions
+          expect(decisions.size).to eq(1)
+          expect(decisions.first.reference).to eq(1234)
+          expect(decisions.first.maat_id).to eq(5678)
+          expect(decisions.first.case_id).to eq('123123123')
+          expect(decisions.first.interests_of_justice).to eq(interests_of_justice)
+          expect(decisions.first.means).to eq(means)
+          expect(decisions.first.funding_decision).to eq('granted')
+          expect(decisions.first.comment).to eq('test comment')
+        end
       end
     end
 


### PR DESCRIPTION
## Description of change
1. Added the missing decision attributes to the `complete` endpoint params.
2. Added `case_id` to `decisions`.
3. Added decision validation to the `CompleteApplication` service.

## Link to relevant ticket
[CRIMAPP-1398](https://dsdmoj.atlassian.net/browse/CRIMAPP-1398)

[CRIMAPP-1398]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ