### PR TITLE
[CRIMAPP-1513] Metabase metadata update

### DIFF
--- a/app/services/redacting/metadata_wrapper.rb
+++ b/app/services/redacting/metadata_wrapper.rb
@@ -8,6 +8,9 @@ module Redacting
         review_status:,
         offence_class:,
         return_reason:,
+        created_at:,
+        office_code:,
+        application_type:,
       }.stringify_keys
     end
 

--- a/app/services/redacting/metadata_wrapper.rb
+++ b/app/services/redacting/metadata_wrapper.rb
@@ -9,6 +9,7 @@ module Redacting
         offence_class:,
         return_reason:,
         created_at:,
+        submitted_at:,
         office_code:,
         application_type:,
       }.stringify_keys

--- a/spec/services/operations/return_application_spec.rb
+++ b/spec/services/operations/return_application_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe Operations::ReturnApplication do
   before do
     CrimeApplication.create(
+      created_at: DateTime.new(2024, 12, 11),
       submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read)
     )
   end
@@ -90,6 +91,10 @@ describe Operations::ReturnApplication do
               'reviewed_at' => application.reviewed_at.to_time.utc.iso8601(3),
               'review_status' => 'returned_to_provider',
               'status' => 'returned',
+              'application_type' => 'initial',
+              'created_at' => '2024-12-11T00:00:00.000Z',
+              'submitted_at' => '2022-10-24T09:50:04.019Z',
+              'office_code' => '1A123B',
             }
           )
         end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -153,8 +153,9 @@ describe Redacting::Redact do
         'offence_class' => nil,
         'return_reason' => nil,
         'application_type' => 'initial',
-        'created_at' => '2024-12-11T12:10:33.302Z',
-        'office_code' => '1A123B',
+        'created_at' => nil,
+        'office_code' => nil,
+        'submitted_at' => nil,
       })
     end
   end

--- a/spec/services/redacting/redact_spec.rb
+++ b/spec/services/redacting/redact_spec.rb
@@ -152,6 +152,9 @@ describe Redacting::Redact do
         'review_status' => 'application_received',
         'offence_class' => nil,
         'return_reason' => nil,
+        'application_type' => 'initial',
+        'created_at' => '2024-12-11T12:10:33.302Z',
+        'office_code' => '1A123B',
       })
     end
   end


### PR DESCRIPTION
## Description of change
Adds attributes to metadata json to fix filtering issue in metabase 

Metabase restricts the number of filter fields for nested json, see warning message:
`WARN metabase.driver.sql-jdbc.sync.describe-table More nested field columns detected than maximum. Limiting the number of nested field columns to 100.`

The `submitted_application` json has exceeded this limit. This meant fields that were previously available to use on metabase to create new reports or filter existing reports were missing or no longer working

As the metadata json is under the limit of 100, making filters of interested available on the metadata should make it possible to filter on those attributes added 

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-1513

## Notes for reviewer / how to test
