### PR TITLE
CRIMAPP-1597 store overall result as a constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'aws-sdk-sns'
 
 gem 'laa-criminal-legal-aid-schemas',
     github: 'ministryofjustice/laa-criminal-legal-aid-schemas',
-    tag: 'v1.5.4'
+    tag: 'v1.6.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-criminal-legal-aid-schemas.git
-  revision: 3fcb1da6f13b61b8ae846c86978cd16dedc4b9a8
-  tag: v1.5.4
+  revision: a47fd2b1127e5c67a2a31b52d42e13f77771c6da
+  tag: v1.6.0
   specs:
-    laa-criminal-legal-aid-schemas (1.5.4)
+    laa-criminal-legal-aid-schemas (1.6.0)
       dry-schema (~> 1.13)
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)

--- a/spec/api/datastore/v1/reviewing/complete_application_spec.rb
+++ b/spec/api/datastore/v1/reviewing/complete_application_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'complete application' do
               'funding_decision' => 'granted',
               'comment' => 'test comment',
               'court_type' => 'crown',
-              'overall_result' => 'Granted - failed means'
+              'overall_result' => 'granted_failed_means'
             }.as_json
           ]
         end
@@ -141,7 +141,7 @@ RSpec.describe 'complete application' do
           expect(decisions.first.funding_decision).to eq('granted')
           expect(decisions.first.comment).to eq('test comment')
           expect(decisions.first.court_type).to eq('crown')
-          expect(decisions.first.overall_result).to eq('Granted - failed means')
+          expect(decisions.first.overall_result).to eq(Types::OverallResult['granted_failed_means'])
         end
       end
     end


### PR DESCRIPTION
## Description of change

The initial plan was to store MAAT strings directly in the datastore overall_result, as MAAT is the source of truth for decisions and its logic is complex. However, testing has shown that these strings do not fully meet providers' needs and may cause confusion.

Instead, we will store a constant representing the overall result, which clients can translate into text as needed. This result will combine the funding_decision with any relevant qualifications that help providers understand the next steps.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1597

## Notes for reviewer / how to test
