### PR TITLE
[CRIMAPP-1523] Target AWS secrets on metabase

### DIFF
--- a/config/kubernetes/metabase/deployment.yml
+++ b/config/kubernetes/metabase/deployment.yml
@@ -53,7 +53,7 @@ spec:
           - configMapRef:
               name: configmap
           - secretRef:
-              name: secrets
+              name: laa-criminal-applications-metabase-secrets
         env:
           # secrets created by terraform
           - name: MB_DB_CONNECTION_URI


### PR DESCRIPTION
## Description of change
Update to the Metabase deployment file to target the new secrets generated by AWS Secrets Manager.

## Link to relevant ticket
[CRIMAPP-1523](https://dsdmoj.atlassian.net/browse/CRIMAPP-1523)

[CRIMAPP-1523]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ