### PR TITLE
[CRIMAPP-1813] Temporarily disable returning records to MAAT in production

### DIFF
--- a/app/services/operations/maat/get_application.rb
+++ b/app/services/operations/maat/get_application.rb
@@ -32,6 +32,8 @@ module Operations
       end
 
       def representation
+        raise ActiveRecord::RecordNotFound if record && Rails.env.production?
+
         Datastore::Entities::V1::MAAT::Application.represent(record)
       end
 

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe 'get application ready for maat' do
       end
     end
 
+    context 'with a ready for assessment application and env is production' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        api_request
+      end
+
+      it 'returns http status 404' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'with a non-means application' do
       before do
         allow(Rails.error).to receive(:report)


### PR DESCRIPTION
## Description of change

This change prevents MAAT users from accessing applications in the production datastore.
It is a temporary measure to allow the datastore to be deployed without exposing data to MAAT.
Since feature flags are not yet implemented on the datastore, this behavior is gated using env.production?.

## Link to relevant ticket

[CRIMAPP-1813](https://dsdmoj.atlassian.net/browse/CRIMAPP-1813)

## Notes for reviewer / how to test


[CRIMAPP-1813]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ