### PR TITLE
[CRIMAPP-1818] Remove Trivy alerts

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,0 @@
-# CVEs that are outside of our control
-#
-
-# Accept all risks until 2025-08-26 - may have been resolved by cloud platform
-CVE-2025-21613 exp:2025-08-26
-CVE-2025-21614 exp:2025-08-26
-CVE-2024-45337 exp:2025-08-26
-CVE-2025-30204 exp:2025-08-26
-CVE-2025-22869 exp:2025-08-26

--- a/config/kubernetes/staging/prometheus.yml
+++ b/config/kubernetes/staging/prometheus.yml
@@ -60,26 +60,6 @@ spec:
       annotations:
         message: Pod `{{ $labels.pod }}` in `{{ $labels.namespace }}` has been in a non-ready state for longer than 1h.
 
-    - alert: CrimeApplyDatastore-TrivyVulns
-      expr: >-
-        sum by (namespace, image_tag, trivy_severity) (
-          label_replace(
-            trivy_image_vulnerabilities{namespace=~"^laa-criminal-applications-datastore.*",severity=~"Critical|High"}
-          >
-            0,
-          "trivy_severity",
-          "$1",
-          "severity",
-          "(.*)"
-          )
-        )
-      for: 1h
-      labels:
-        severity: laa-crime-apply-alerts
-      annotations:
-        message: Image `{{ $labels.image_tag }}` in namespace `{{ $labels.namespace }}` has {{ $value }} {{ $labels.trivy_severity }} vulnerabilities.
-        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/trivy_starboard_operator123/trivy-operator-image-vulnerability?orgId=1&from=now-24h&to=now&var-namespace={{ $labels.namespace }}
-
     - alert: CrimeApplyDatastore-DLQNotEmpty
       expr: >-
         sum(aws_sqs_approximate_number_of_messages_visible_maximum{queue_name=~"^laa-crime-apply-(staging|production)-application-events-dlq"} offset 5m) 


### PR DESCRIPTION
## Description of change
This change removes Prometheus Trivy alerts and `.trivyignore` as we've switched to Snyk for container image scanning.

## Link to relevant ticket
[CRIMAPP-1818](https://dsdmoj.atlassian.net/browse/CRIMAPP-1818)

[CRIMAPP-1818]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ