### PR TITLE
[CRIMAPP-1821] Add SQS to LocalStack

### DIFF
--- a/config/localstack/ready.sh
+++ b/config/localstack/ready.sh
@@ -8,6 +8,8 @@
 ENDPOINT="https://localhost.localstack.cloud:4566"
 BUCKET_NAME="crime-apply-documents-dev"
 SNS_TOPIC_NAME="events-sns-topic-dev"
+SQS_DLQ_NAME="events-sqs-dlq-dev"
+SQS_QUEUE_NAME="events-sqs-queue-dev"
 # This is the Review endpoint where notifications are sent
 SNS_NOTIFICATION_ENDPOINT="http://host.docker.internal:3001/api/events"
 
@@ -18,11 +20,19 @@ aws s3api create-bucket --bucket $BUCKET_NAME --endpoint-url=$ENDPOINT > /dev/nu
 echo "Creating local SNS topic..."
 SNS_TOPIC_ARN=$(aws sns create-topic --name $SNS_TOPIC_NAME --endpoint-url=$ENDPOINT --output text --query 'TopicArn')
 
-echo "Subscribing notification endpoint to SNS topic..."
+echo "Creating local SQS dead letter queue..."
+SQS_DLQ_URL=$(aws sqs create-queue --queue-name $SQS_DLQ_NAME --endpoint-url=$ENDPOINT --output text --query 'QueueUrl')
+SQS_DLQ_ARN=$(aws sqs get-queue-attributes --queue-url $SQS_DLQ_URL --endpoint-url=$ENDPOINT --attribute-names 'QueueArn' --output text --query 'Attributes.QueueArn')
+
+echo "Creating local SQS queue..."
+SQS_QUEUE_URL=$(aws sqs create-queue --queue-name $SQS_QUEUE_NAME --endpoint-url=$ENDPOINT --attributes '{"RedrivePolicy": "{\"deadLetterTargetArn\":\"'$SQS_DLQ_ARN'\",\"maxReceiveCount\": \"1\"}", "MessageRetentionPeriod": "1209600"}' --output text --query 'QueueUrl')
+SQS_QUEUE_ARN=$(aws sqs get-queue-attributes --queue-url $SQS_QUEUE_URL --endpoint-url=$ENDPOINT --attribute-names 'QueueArn' --output text --query 'Attributes.QueueArn')
+
+echo "Subscribing SQS queue to SNS topic..."
 aws sns subscribe \
     --topic-arn "$SNS_TOPIC_ARN" --endpoint-url "$ENDPOINT" \
-    --protocol http --notification-endpoint "$SNS_NOTIFICATION_ENDPOINT" \
-    --attributes '{"RawMessageDelivery":"false","FilterPolicyScope":"MessageBody","FilterPolicy":"{\"event_name\":[\"apply.submission\"]}"}' > /dev/null
+    --protocol sqs --notification-endpoint "$SQS_QUEUE_ARN" \
+    --attributes '{"FilterPolicy":"{\"event_name\":[\"apply.submission\"]}"}' > /dev/null
 
 echo
 echo "[-- Local development configuration --]"
@@ -42,6 +52,10 @@ echo
 echo "  EVENTS_SNS_TOPIC_ARN=$SNS_TOPIC_ARN"
 echo "  S3_BUCKET_NAME=$BUCKET_NAME"
 echo
-echo "The SNS notification subscription will fail if Review is not running."
-echo "Unless you are working on notifications, it is safe to ignore."
+echo "Declare the following in Review to start polling messages:"
+echo
+echo "  AWS_REGION=us-east-1"
+echo "  AWS_ACCESS_KEY_ID=test"
+echo "  AWS_SECRET_ACCESS_KEY=test"
+echo "  SQS_QUEUE_URL=$SQS_QUEUE_URL"
 echo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       AWS_DEFAULT_REGION: us-east-1 # only this region works for SNS in localstack
       S3_SKIP_SIGNATURE_VALIDATION: 0
       DOCKER_HOST: unix:///var/run/docker.sock
-      SERVICES: s3,sns
+      SERVICES: s3,sns,sqs
     volumes:
       - ./config/localstack/ready.sh:/etc/localstack/init/ready.d/ready.sh
       - ./config/localstack/shutdown.sh:/etc/localstack/init/shutdown.d/shutdown.sh


### PR DESCRIPTION
## Description of change
Accompanying Review PR: https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/905

This change adds SQS to LocalStack and subscribes a queue to SNS so that the new SQS <--> SNS messaging system can be replicated locally.

## Link to relevant ticket
[CRIMAPP-1821](https://dsdmoj.atlassian.net/browse/CRIMAPP-1821)

[CRIMAPP-1821]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ