### PR TITLE
[CRIMAPP-1943] Add deletion read model

### DIFF
--- a/app/models/deletable_entity.rb
+++ b/app/models/deletable_entity.rb
@@ -1,0 +1,2 @@
+class DeletableEntity < ApplicationRecord
+end

--- a/db/migrate/20250917105253_create_deletable_entities.rb
+++ b/db/migrate/20250917105253_create_deletable_entities.rb
@@ -1,0 +1,9 @@
+class CreateDeletableEntities < ActiveRecord::Migration[7.2]
+  def change
+    create_table :deletable_entities, id: :uuid do |t|
+      t.string :business_reference, index: { unique: true }
+      t.datetime :review_deletion_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_16_115333) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_17_105253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -66,6 +66,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_16_115333) do
     t.string "assessment_rules"
     t.string "overall_result"
     t.index ["crime_application_id"], name: "index_decisions_on_crime_application_id"
+  end
+
+  create_table "deletable_entities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "business_reference"
+    t.datetime "review_deletion_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["business_reference"], name: "index_deletable_entities_on_business_reference", unique: true
   end
 
   create_table "event_store_events", force: :cascade do |t|

--- a/spec/application_events/deleting_spec.rb
+++ b/spec/application_events/deleting_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Deleting do
       it 'is eligible for deletion' do
         expect(deletable.soft_deletable?).to be(true)
       end
+
+      it 'sets the `review_deletion_at` timestamp on the read model' do
+        expect(DeletableEntity.find_by(business_reference:).review_deletion_at).to eq(Time.zone.local(2023, 9,
+                                                                                                      4) + 2.years)
+      end
     end
 
     context 'when sent back 2 years ago and was injected into MAAT' do
@@ -121,6 +126,11 @@ RSpec.describe Deleting do
       it 'is not eligible for deletion' do
         expect(deletable.soft_deletable?).to be(false)
       end
+
+      it 'sets the `review_deletion_at` timestamp on the read model' do
+        expect(DeletableEntity.find_by(business_reference:).review_deletion_at).to eq(Time.zone.local(2023, 9,
+                                                                                                      4) + 2.years)
+      end
     end
 
     context 'when sent back 2 years ago and has active drafts' do
@@ -170,6 +180,11 @@ RSpec.describe Deleting do
 
       it 'is not eligible for deletion' do
         expect(deletable.soft_deletable?).to be(false)
+      end
+
+      it 'sets the `review_deletion_at` timestamp on the read model' do
+        expect(DeletableEntity.find_by(business_reference:).review_deletion_at).to eq(Time.zone.local(2023, 9,
+                                                                                                      5) + 2.years)
       end
     end
   end


### PR DESCRIPTION
## Description of change
- create `deletable_entities` as a read model to support deletion work
- create subscriber class `UpdateReadModel` to update `deletable_entities`

## Link to relevant ticket
[CRIMAPP-1943](https://dsdmoj.atlassian.net/browse/CRIMAPP-1943)

[CRIMAPP-1943]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ