### PR TITLE
[CRIMAPP-1903] Add endpoint to publish MaatRecordCreated event

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ At the moment these endpoints are:
 Endpoints used by MAAT adapter:
 
 * `GET /api/v1/maat/applications/{usn}` get an application by its USN
+* `POST /api/v1/maat/applications/maat_record_created` creates a MaatRecordCreated event

--- a/app/api/datastore/v1/maat/applications.rb
+++ b/app/api/datastore/v1/maat/applications.rb
@@ -17,6 +17,17 @@ module Datastore
               Operations::MAAT::GetApplication.new(reference: params[:usn]).call
             end
           end
+
+          desc 'Create a MaatRecordCreated event for an application.'
+          params do
+            requires :entity_id, type: String, desc: 'Application UUID.'
+            requires :entity_type, type: String, values: Types::APPLICATION_TYPES, desc: 'Application type.'
+            requires :business_reference, type: String, desc: 'Application reference number.'
+            requires :maat_id, type: String, desc: 'Id of the MAAT record.'
+          end
+          post 'maat_record_created' do
+            Operations::MAATRecordCreated.new(**declared(params).symbolize_keys).call
+          end
         end
       end
     end

--- a/app/services/operations/maat_record_created.rb
+++ b/app/services/operations/maat_record_created.rb
@@ -1,0 +1,17 @@
+module Operations
+  class MAATRecordCreated
+    attr_reader :entity_id, :entity_type, :business_reference, :maat_id
+
+    def initialize(entity_id:, entity_type:, business_reference:, maat_id:)
+      @entity_id = entity_id
+      @entity_type = entity_type
+      @business_reference = business_reference
+      @maat_id = maat_id
+    end
+
+    def call
+      event = Deciding::MaatRecordCreated.new(data: { entity_id:, entity_type:, business_reference:, maat_id: })
+      Rails.configuration.event_store.publish(event)
+    end
+  end
+end

--- a/spec/api/datastore/v1/maat/maat_record_created_spec.rb
+++ b/spec/api/datastore/v1/maat/maat_record_created_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'create a MaatRecordCreated event' do
+  let(:operation_class) { Operations::MAATRecordCreated }
+  let(:stubbed_operation) { instance_double(operation_class, call: {}) }
+
+  let(:entity_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+  let(:entity_type) { 'initial' }
+  let(:business_reference) { '7000001' }
+  let(:maat_id) { '987654321' }
+
+  before do
+    allow(
+      operation_class
+    ).to receive(:new).with(entity_id:, entity_type:, business_reference:, maat_id:).and_return(stubbed_operation)
+  end
+
+  describe 'POST /api/v1/maat/applications/maat_record_created' do
+    subject(:api_request) do
+      post '/api/v1/maat/applications/maat_record_created',
+           params: { entity_id:, entity_type:, business_reference:, maat_id: }
+    end
+
+    it_behaves_like 'an authorisable endpoint', %w[maat-adapter maat-adapter-dev maat-adapter-uat] do
+      before { api_request }
+    end
+  end
+end

--- a/spec/services/operations/maat_record_created_spec.rb
+++ b/spec/services/operations/maat_record_created_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Operations::MAATRecordCreated do
+  subject { described_class.new(entity_id:, entity_type:, business_reference:, maat_id:) }
+
+  let(:entity_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
+  let(:entity_type) { Types::ApplicationType['initial'] }
+  let(:business_reference) { '7000001' }
+  let(:maat_id) { '987654321' }
+  let(:deleting_stream) { Rails.configuration.event_store.read.stream("Deleting$#{business_reference}") }
+  let(:event) { Rails.configuration.event_store.read.stream("Deleting$#{business_reference}").first }
+
+  describe '#call' do
+    it 'publishes a MaatRecordCreated event with the expected attributes' do
+      expect(deleting_stream.map(&:event_type)).to match []
+      subject.call
+      expect(deleting_stream.map(&:event_type)).to match ['Deciding::MaatRecordCreated']
+      expect(event.data).to eq({ entity_id: '696dd4fd-b619-4637-ab42-a5f4565bcf4a', entity_type: 'initial',
+                                 business_reference: '7000001', maat_id: '987654321' })
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds endpoint to publish event when a MAAT record is created for an application

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-1903 (related ticket)

## Notes for reviewer / how to test
