### PR TITLE
[CRIMAPP-1945] Add soft_deleted_at

### DIFF
--- a/db/migrate/20251002105112_add_soft_deleted_at_to_crime_applications.rb
+++ b/db/migrate/20251002105112_add_soft_deleted_at_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddSoftDeletedAtToCrimeApplications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :crime_applications, :soft_deleted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_18_095054) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_02_105112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_18_095054) do
     t.virtual "case_type", type: :string, as: "((submitted_application -> 'case_details'::text) ->> 'case_type'::text)", stored: true
     t.virtual "application_type", type: :string, as: "(submitted_application ->> 'application_type'::text)", stored: true
     t.datetime "archived_at", precision: nil
+    t.datetime "soft_deleted_at", precision: nil
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["application_type"], name: "index_crime_applications_on_application_type"
     t.index ["archived_at"], name: "index_crime_applications_on_archived_at", where: "(archived_at IS NULL)"

--- a/deleting/lib/deleting.rb
+++ b/deleting/lib/deleting.rb
@@ -26,7 +26,7 @@ module Deleting
 
   class Configuration
     class << self
-      def call(event_store)
+      def call(event_store) # rubocop:disable Metrics/MethodLength
         event_store.subscribe(Deleting::Handlers::LinkToStream, to:
           [
             Applying::DraftCreated,
@@ -39,6 +39,7 @@ module Deleting
             Reviewing::Completed
           ])
         event_store.subscribe(Deleting::Handlers::UpdateReadModel, to: EVENTS)
+        event_store.subscribe(Deleting::Handlers::UpdateApplicationSoftDeleted, to: [Deleting::SoftDeleted])
       end
     end
   end

--- a/deleting/lib/deleting/commands/delete.rb
+++ b/deleting/lib/deleting/commands/delete.rb
@@ -24,23 +24,20 @@ module Deleting
       attr_reader :business_reference, :reason, :deleted_by
 
       def soft_delete(deletable)
-        # TODO: update crime_application.soft_deleted_at ? is that necessary?
-        # could we just rely on the aggregate to tell us if/when an app was soft_deleted and expose in API responses?
-        # if we're updating soft_deleted_at, should we update it on all past/superseded apps?
         deletable.soft_delete(entity_id:, reason:, deleted_by:)
       end
 
       def hard_delete(deletable)
         # TODO: redact latest and superseded records
         # TODO: remove attachments
-        DeletionEntry.create!(
+        deletion_entry = DeletionEntry.create!(
           record_id: entity_id,
           record_type: Types::RecordType['application'],
           business_reference: business_reference,
           deleted_by: deleted_by,
           reason: reason
         )
-        deletable.hard_delete(entity_id:)
+        deletable.hard_delete(entity_id: entity_id, deletion_entry_id: deletion_entry.id)
       end
 
       def entity_id

--- a/deleting/lib/deleting/handlers/update_application_soft_deleted.rb
+++ b/deleting/lib/deleting/handlers/update_application_soft_deleted.rb
@@ -1,0 +1,11 @@
+module Deleting
+  module Handlers
+    class UpdateApplicationSoftDeleted
+      def call(event)
+        crime_application = CrimeApplication.find(event.data.fetch(:entity_id))
+        soft_deleted_at = event.metadata.fetch(:timestamp)
+        crime_application.update!(soft_deleted_at:)
+      end
+    end
+  end
+end

--- a/spec/deleting/automate_deletion_returned_application_spec.rb
+++ b/spec/deleting/automate_deletion_returned_application_spec.rb
@@ -63,8 +63,12 @@ RSpec.describe Deleting::AutomateDeletion do
         )
       end
 
-      it 'pushes the `review_deletion_at` timestamp on the read model forward by two weeks' do
+      it 'pushes the `review_deletion_at` timestamp on the read model back by two weeks' do
         expect(deletable_entity.reload.review_deletion_at).to eq(current_date + 2.weeks)
+      end
+
+      it 'sets `soft_deleted_at` on the application' do
+        expect(crime_application.reload.soft_deleted_at).to be_within(2.seconds).of(Time.zone.now)
       end
 
       context 'when two weeks have passed' do
@@ -82,9 +86,10 @@ RSpec.describe Deleting::AutomateDeletion do
           expect(hard_deleted_events.count).to eq(1)
           expect(hard_deleted_events.first.data).to eq(
             {
-              entity_id:,
-              entity_type:,
-              business_reference:
+              entity_id: entity_id,
+              entity_type: entity_type,
+              business_reference: business_reference,
+              deletion_entry_id: DeletionEntry.first.id,
             }
           )
         end
@@ -142,8 +147,12 @@ RSpec.describe Deleting::AutomateDeletion do
         expect(events_in_stream.of_type([Deleting::SoftDeleted]).count).to eq(0)
       end
 
-      it 'does not push the `review_deletion_at` timestamp on the read model forward' do
+      it 'does not push the `review_deletion_at` timestamp on the read model back' do
         expect(deletable_entity.reload.review_deletion_at).to eq(Time.zone.local(2023, 9, 4) + 2.years)
+      end
+
+      it 'does not set `soft_deleted_at` on the application' do
+        expect(crime_application.reload.soft_deleted_at).to be_nil
       end
     end
 
@@ -181,8 +190,12 @@ RSpec.describe Deleting::AutomateDeletion do
         expect(events_in_stream.of_type([Deleting::SoftDeleted]).count).to eq(0)
       end
 
-      it 'does not push the `review_deletion_at` timestamp on the read model forward' do
+      it 'does not push the `review_deletion_at` timestamp on the read model back' do
         expect(deletable_entity.reload.review_deletion_at).to eq(Time.zone.local(2023, 9, 5) + 2.years)
+      end
+
+      it 'does not set `soft_deleted_at` on the application' do
+        expect(crime_application.reload.soft_deleted_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Description of change
- add `soft_deleted_at` to `crime_applications`
- link `UpdateApplicationSoftDeleted` listener to `SoftDeleted` event to update the application's `soft_deleted_at` timestamp
- add `state` to `Deletable` aggregate

## Link to relevant ticket
[CRIMAPP-1945](https://dsdmoj.atlassian.net/browse/CRIMAPP-1945)

[CRIMAPP-1945]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ