### PR TITLE
[CRIMAPP-1948] Add maat_id to crime applications

### DIFF
--- a/db/migrate/20251008163141_add_maat_id_to_crime_applications.rb
+++ b/db/migrate/20251008163141_add_maat_id_to_crime_applications.rb
@@ -1,0 +1,5 @@
+class AddMAATIdToCrimeApplications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :crime_applications, :maat_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_02_105112) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_08_163141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_02_105112) do
     t.virtual "application_type", type: :string, as: "(submitted_application ->> 'application_type'::text)", stored: true
     t.datetime "archived_at", precision: nil
     t.datetime "soft_deleted_at", precision: nil
+    t.integer "maat_id"
     t.index ["applicant_last_name", "applicant_first_name"], name: "index_crime_applications_on_applicant_name"
     t.index ["application_type"], name: "index_crime_applications_on_application_type"
     t.index ["archived_at"], name: "index_crime_applications_on_archived_at", where: "(archived_at IS NULL)"


### PR DESCRIPTION
## Description of change
- add `maat_id` to the `crime_applications` table to store MAAT IDs

This is in preparation for a migration to backfill the MAAT IDs for existing applications. Applications completed since the introduction of funding decisions will already have their `maat_id` stored in the `decisions` table, however older applications will not have a decision record.

## Link to relevant ticket
[CRIMAPP-1948](https://dsdmoj.atlassian.net/browse/CRIMAPP-1948)

[CRIMAPP-1948]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ