### PR TITLE
[CRIMAPP-1969] use anonymised application details when soft deleted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-schema (1.14.0)
+    dry-schema (1.14.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 1.0, >= 1.0.1)
       dry-core (~> 1.1)

--- a/app/api/datastore/entities/v1/base_application_entity.rb
+++ b/app/api/datastore/entities/v1/base_application_entity.rb
@@ -13,6 +13,7 @@ module Datastore
         expose :parent_id
         expose :created_at
         expose :work_stream
+        expose :soft_deleted_at, expose_nil: false
 
         private
 
@@ -28,6 +29,12 @@ module Datastore
           case_details = submitted_value('case_details') || {}
           case_details['offence_class'] = object.offence_class
           case_details
+        end
+
+        def submitted_at
+          return object.submitted_at if object.soft_deleted_at.blank?
+
+          object.submitted_at.in_time_zone('London').at_midnight
         end
 
         def client_details

--- a/spec/api/datastore/entities/v1/crime_application_spec.rb
+++ b/spec/api/datastore/entities/v1/crime_application_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Datastore::Entities::V1::CrimeApplication do
       offence_class: Types::OffenceClass['C'],
       work_stream: Types::WorkStreamType['criminal_applications_team'],
       submitted_application: submitted_application,
-      decisions: []
+      decisions: [],
+      soft_deleted_at: nil
     )
   end
 

--- a/spec/api/datastore/entities/v1/maat/application_spec.rb
+++ b/spec/api/datastore/entities/v1/maat/application_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Datastore::Entities::V1::MAAT::Application do
       return_details: { reason: nil, details: nil, returned_at: nil },
       offence_class: Types::OffenceClass['C'],
       work_stream: Types::WorkStreamType['criminal_applications_team'],
-      submitted_application: submitted_application
+      submitted_application: submitted_application,
+      soft_deleted_at: nil
     )
   end
 

--- a/spec/api/datastore/entities/v1/post_submission_evidence_application_spec.rb
+++ b/spec/api/datastore/entities/v1/post_submission_evidence_application_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Datastore::Entities::V1::PostSubmissionEvidenceApplication do
       return_details: { reason: nil, details: nil, returned_at: nil },
       offence_class: Types::OffenceClass['C'],
       work_stream: Types::WorkStreamType['criminal_applications_team'],
-      submitted_application: submitted_application
+      submitted_application: submitted_application,
+      soft_deleted_at: nil
     )
   end
 

--- a/spec/api/datastore/v1/applications/list_applications_spec.rb
+++ b/spec/api/datastore/v1/applications/list_applications_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe 'list applications' do
     describe 'scoping by consumer' do
       let(:applications) do
         super() << {
-          submitted_application: { reference: 6_000_004 },
+          submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('reference' => 6_000_004),
           status: 'returned', submitted_at: 1.year.ago, returned_at: 1.year.ago,
           archived_at: nil, soft_deleted_at: 1.day.ago
         }

--- a/spec/api/datastore/v1/searching/scoped_by_consumer_spec.rb
+++ b/spec/api/datastore/v1/searching/scoped_by_consumer_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'scope search by consumer' do
           archived_at: nil, soft_deleted_at: nil
         },
         {
-          submitted_application: { reference: 6_000_004 },
+          submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('reference' => 6_000_004),
           status: 'returned', submitted_at: 1.year.ago, returned_at: 1.year.ago,
           archived_at: nil, soft_deleted_at: 1.day.ago
         }


### PR DESCRIPTION
- return anonymised application_details for soft deleted crime applications
- expose soft_deleted_at

[CRIMAPP-1969](https://dsdmoj.atlassian.net/browse/CRIMAPP-1969)

Persisting of anonymised details on hard delete to come later

[CRIMAPP-1969]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ