### PR TITLE
[CRIMAPP-1948] MAAT ID backfill task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ gem 'benchmark', '~> 0.4.0'
 gem 'rails_event_store'
 
 gem 'aggregate_root'
+
+gem 'csv', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.9.1)
       irb (~> 1.10)
@@ -439,6 +440,7 @@ DEPENDENCIES
   benchmark (~> 0.4.0)
   brakeman
   byebug
+  csv (~> 3.3)
   debug
   dotenv-rails (~> 2.8.1)
   grape

--- a/lib/tasks/backfill_maat_ids.rake
+++ b/lib/tasks/backfill_maat_ids.rake
@@ -1,0 +1,21 @@
+desc 'Backfill MAAT IDs from a CSV export'
+task :backfill_maat_ids, [:csv_path] => :environment do |task, args|
+  require 'csv'
+
+  csv_path = args[:csv_path]
+
+  mapped_usns = []
+  CSV.foreach(csv_path, headers: true) do |row|
+    crime_application = CrimeApplication.find_by(reference: row['USN'].to_i)
+    if crime_application.present?
+      crime_application.update!(maat_id: row['MAAT_ID'].to_i)
+      mapped_usns << crime_application.reference
+    end
+  end
+
+  CSV.open('/tmp/mapped_usns.csv', 'w', write_headers: true, headers: ['USN']) do |csv|
+    mapped_usns.each { |usn| csv << [usn.to_s] }
+  end
+
+  puts 'Done'
+end


### PR DESCRIPTION
## Description of change
- add a `backfill_maat_ids` rake task to import MAAT IDs for historic applications, which will be picked up by the event stream migration task

The actual format in which the MAAT ID extract will come is still to be confirmed.

## Link to relevant ticket
[CRIMAPP-1948](https://dsdmoj.atlassian.net/browse/CRIMAPP-1948)

[CRIMAPP-1948]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ