### PR TITLE
[CRIMAPP-1948] Change draft endpoint business_reference type to int

### DIFF
--- a/app/api/datastore/v1/applications.rb
+++ b/app/api/datastore/v1/applications.rb
@@ -82,7 +82,7 @@ module Datastore
         params do
           requires :entity_id, type: String, desc: 'Draft application UUID.'
           requires :entity_type, type: String, values: Types::APPLICATION_TYPES, desc: 'Draft application type.'
-          requires :business_reference, type: String, desc: 'Draft application reference number.'
+          requires :business_reference, type: Integer, desc: 'Draft application reference number.'
           optional :created_at, type: Time, desc: 'Draft application creation timestamp.'
         end
         post 'draft_created' do
@@ -94,7 +94,7 @@ module Datastore
         params do
           requires :entity_id, type: String, desc: 'Draft application UUID.'
           requires :entity_type, type: String, values: Types::APPLICATION_TYPES, desc: 'Draft application type.'
-          requires :business_reference, type: String, desc: 'Draft application reference number.'
+          requires :business_reference, type: Integer, desc: 'Draft application reference number.'
         end
         post 'draft_updated' do
           Operations::DraftUpdated.new(**declared(params).symbolize_keys).call
@@ -105,7 +105,7 @@ module Datastore
         params do
           requires :entity_id, type: String, desc: 'Draft application UUID.'
           requires :entity_type, type: String, values: Types::APPLICATION_TYPES, desc: 'Draft application type.'
-          requires :business_reference, type: String, desc: 'Draft application reference number.'
+          requires :business_reference, type: Integer, desc: 'Draft application reference number.'
           requires :reason, type: String, values: Types::DELETION_REASONS, desc: 'Deletion reason.'
           requires :deleted_by, type: String, desc: 'Who the application was deleted by.'
         end

--- a/spec/api/datastore/v1/applications/draft_created_spec.rb
+++ b/spec/api/datastore/v1/applications/draft_created_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'create a DraftCreated event' do
 
   let(:entity_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
   let(:entity_type) { 'initial' }
-  let(:business_reference) { '7000001' }
+  let(:business_reference) { 7_000_001 }
   let(:created_at) { nil }
 
   before do

--- a/spec/api/datastore/v1/applications/draft_deleted_spec.rb
+++ b/spec/api/datastore/v1/applications/draft_deleted_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'create a DraftDeleted event' do
 
   let(:entity_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
   let(:entity_type) { 'initial' }
-  let(:business_reference) { '7000001' }
+  let(:business_reference) { 7_000_001 }
   let(:reason) { 'retention_rule' }
   let(:deleted_by) { '1' }
 

--- a/spec/api/datastore/v1/applications/draft_updated_spec.rb
+++ b/spec/api/datastore/v1/applications/draft_updated_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'create a DraftUpdated event' do
 
   let(:entity_id) { '696dd4fd-b619-4637-ab42-a5f4565bcf4a' }
   let(:entity_type) { 'initial' }
-  let(:business_reference) { '7000001' }
+  let(:business_reference) { 7_000_001 }
 
   before do
     allow(


### PR DESCRIPTION
## Description of change
- update the `business_reference` param type from String to Integer on draft event API endpoints

This is to make the `business_reference` type consistent across all event types, where the type will normally be an integer.

## Link to relevant ticket
[CRIMAPP-1948](https://dsdmoj.atlassian.net/browse/CRIMAPP-1948)

[CRIMAPP-1948]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ