### PR TITLE
[CRIMAPP-1953] Always log automated deletion

### DIFF
--- a/lib/tasks/automate_deletion.rake
+++ b/lib/tasks/automate_deletion.rake
@@ -1,13 +1,10 @@
 desc 'Automatically perform soft and hard deletion of applications that have reached the end of their retention period'
 task automate_deletion: [:environment] do
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    $stdout.sync = true
-    logger = ActiveSupport::Logger.new($stdout)
-    logger.formatter = Logger::Formatter.new
-    logger.level = Logger::INFO
-
-    Rails.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
+  $stdout.sync = true
+  logger = ActiveSupport::Logger.new($stdout)
+  logger.formatter = Logger::Formatter.new
+  logger.level = Logger::INFO
+  Rails.logger = ActiveSupport::TaggedLogging.new(logger)
   
   Deleting::AutomateDeletion.call
 end


### PR DESCRIPTION
## Description of change
- remove the check for undefined `RAILS_LOG_TO_STDOUT` env variable in the `automate_deletion` task and always enable logging for automated deletion

## Link to relevant ticket
[CRIMAPP-1953](https://dsdmoj.atlassian.net/browse/CRIMAPP-1953)

[CRIMAPP-1953]: https://dsdmoj.atlassian.net/browse/CRIMAPP-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ