### PR TITLE
Fix expired drafts in deletable_entities bug

### DIFF
--- a/deleting/lib/deleting.rb
+++ b/deleting/lib/deleting.rb
@@ -44,6 +44,7 @@ module Deleting
         event_store.subscribe(Deleting::Handlers::UpdateReadModel, to: EVENTS)
         event_store.subscribe(Deleting::Handlers::UpdateApplicationSoftDeleted, to: [Deleting::SoftDeleted])
         event_store.subscribe(Deleting::Handlers::ClearApplicationSoftDeleted, to: [Deleting::ExemptFromDeletion])
+        event_store.subscribe(Deleting::Handlers::DeleteUnsubmittedDeletableEntity, to: [Applying::DraftDeleted])
       end
     end
   end

--- a/deleting/lib/deleting/commands/delete.rb
+++ b/deleting/lib/deleting/commands/delete.rb
@@ -15,6 +15,7 @@ module Deleting
           elsif deletable.soft_deletable?
             soft_delete(deletable)
           else
+            # This may happen if there is a draft application in Apply pending hard-deletion
             Rails.logger.warn("Application #{business_reference} is not ready for deletion")
           end
         end

--- a/deleting/lib/deleting/deletable.rb
+++ b/deleting/lib/deleting/deletable.rb
@@ -162,6 +162,10 @@ module Deleting
       @deletion_at <= Time.zone.now
     end
 
+    def never_submitted?
+      @submitted_at.nil?
+    end
+
     private
 
     def active_drafts?
@@ -184,10 +188,6 @@ module Deleting
       return 7.years if granted?
 
       2.years
-    end
-
-    def never_submitted?
-      @submitted_at.nil?
     end
 
     def completed_without_decision?

--- a/deleting/lib/deleting/handlers/delete_unsubmitted_deletable_entity.rb
+++ b/deleting/lib/deleting/handlers/delete_unsubmitted_deletable_entity.rb
@@ -1,0 +1,16 @@
+module Deleting
+  module Handlers
+    class DeleteUnsubmittedDeletableEntity
+      def call(event)
+        return unless event.instance_of?(Applying::DraftDeleted)
+
+        business_reference = event.data.fetch(:business_reference)
+        repository = Deleting::DeletableRepository.new
+        repository.with_deletable(business_reference) do |deletable|
+          deletable_entity = DeletableEntity.find_by(business_reference:)
+          deletable_entity.destroy! if deletable_entity.present? && deletable.never_submitted?
+        end
+      end
+    end
+  end
+end

--- a/spec/deleting/handlers/delete_unsubmitted_deletable_entity_spec.rb
+++ b/spec/deleting/handlers/delete_unsubmitted_deletable_entity_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe Deleting::Handlers::DeleteUnsubmittedDeletableEntity do
+  include_context 'with published events'
+
+  let(:event_stream) { "Deleting$#{business_reference}" }
+
+  def publish_draft_deleted
+    event_store.publish(Applying::DraftDeleted.new(data:
+        {
+          entity_id: entity_id, entity_type: entity_type,
+          business_reference: business_reference,
+          reason: 'retention_rule',
+          deleted_by: SecureRandom.uuid
+        }))
+  end
+
+  context 'when DraftDeleted is published for an unsubmitted application' do
+    let(:entity_id) { SecureRandom.uuid }
+    let(:business_reference) { '6000001' }
+    let(:entity_type) { 'initial' }
+
+    let(:events) do
+      [
+        Applying::DraftCreated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: }
+      ]
+    end
+
+    before do
+      publish_events
+    end
+
+    it 'deletes the DeletableEntity record' do
+      expect { publish_draft_deleted }.to change(DeletableEntity, :count).from(1).to(0)
+    end
+  end
+
+  context 'when DraftDeleted is published for a submitted application' do
+    let!(:crime_application) do
+      CrimeApplication.create!(submitted_application: JSON.parse(LaaCrimeSchemas.fixture(1.0).read))
+    end
+    let(:entity_id) { crime_application.id }
+    let(:business_reference) { crime_application.reference }
+    let(:entity_type) { crime_application.application_type }
+
+    let(:events) do
+      [
+        Applying::DraftCreated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::DraftUpdated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
+        Applying::Submitted, Time.zone.local(2023, 9, 1), { entity_id:, entity_type:, business_reference: },
+        Reviewing::SentBack, Time.zone.local(2023, 9, 4), { entity_id: entity_id, entity_type: entity_type,
+                                                              business_reference: business_reference,
+                                                              reason: 'duplicate_application' },
+        Applying::DraftCreated, Time.zone.local(2023, 9, 4), { entity_id:, entity_type:, business_reference: },
+      ]
+    end
+
+    before do
+      publish_events
+    end
+
+    it 'does not delete the DeletableEntity record' do
+      expect { publish_draft_deleted }.not_to change(DeletableEntity, :count).from(1)
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
- adds `DeleteUnsubmittedDeletableEntity` handler that listens for `Applying::DraftDeleted` events, destroying the `DeletableEntity` record if the application was never submitted

This bug was discovered when checking the production Datastore for applications eligible for soft-deletion.

In production, this bug has caused the `deletable_entities` table to accumulate records corresponding to draft applications that were never submitted and deleted in Apply. Once soft-deletion is in production, this would leave the `AutomateDeletion` service to loop through an increasing number of these "ghost" records. As `DraftDeleted` signifies either a manual deletion by the provider or a hard deletion by the system, it is safe to destroy the `DeletableEntity` record as a result. This will prevent future occurrences of this bug.

A one-off script to remove existing ghost records will be added in another PR.