### PR TITLE
Nilify soft_delete_at in Deletable aggregate on exemption

### DIFF
--- a/deleting/lib/deleting/deletable.rb
+++ b/deleting/lib/deleting/deletable.rb
@@ -5,7 +5,7 @@ module Deleting
     class AlreadyHardDeleted < StandardError; end
     class CannotBeExempt < StandardError; end
 
-    attr_reader :business_reference, :deletion_at, :state
+    attr_reader :business_reference, :deletion_at, :state, :soft_deleted_at
 
     STATES = [:submitted, :decided, :completed, :returned, :soft_deleted, :hard_deleted, :exempt_from_deletion].freeze
     REVIEW_STATUS_TO_STATE = {
@@ -87,6 +87,7 @@ module Deleting
       @exemption_reason = event.data.fetch(:reason)
       @exempt_until = event.data.fetch(:exempt_until, nil)
       @deletion_at = @exempt_until || (timestamp(event) + retention_period)
+      @soft_deleted_at = nil
     end
 
     on Deleting::ApplicationMigrated do |event|

--- a/spec/deleting/commands/exempt_spec.rb
+++ b/spec/deleting/commands/exempt_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Deleting::Commands::Exempt do
   let(:entity_type) { crime_application.application_type }
   let(:event_stream) { "Deleting$#{business_reference}" }
   let(:current_date) { Time.zone.local(2025, 9, 6) }
+  let(:repository) { Deleting::DeletableRepository.new }
 
   let(:events) do
     [
@@ -63,6 +64,12 @@ RSpec.describe Deleting::Commands::Exempt do
 
     it 'clears the soft_deleted_at timestamp' do
       expect(crime_application.reload.soft_deleted_at).to be_nil
+    end
+
+    it 'clears the soft_deleted_at timestamp in the aggregate' do
+      repository.with_deletable(business_reference) do |deletable|
+        expect(deletable.soft_deleted_at).to be_nil
+      end
     end
 
     it 'sets `review_deletion_at` to the given date' do


### PR DESCRIPTION
## Description of change
- sets `soft_deleted_at` to nil in the `Deletable` aggregate when an `ExemptFromDeletion` event is received

This was overlooked in PR https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/438.