### PR TITLE
Ensure superseded applications are soft-deleted

### DIFF
--- a/deleting/lib/deleting/handlers/update_application_soft_deleted.rb
+++ b/deleting/lib/deleting/handlers/update_application_soft_deleted.rb
@@ -2,9 +2,9 @@ module Deleting
   module Handlers
     class UpdateApplicationSoftDeleted
       def call(event)
-        crime_application = CrimeApplication.find(event.data.fetch(:entity_id))
+        crime_applications = CrimeApplication.where(reference: event.data.fetch(:business_reference))
         soft_deleted_at = event.metadata.fetch(:timestamp)
-        crime_application.update!(soft_deleted_at:)
+        crime_applications.update_all(soft_deleted_at:) # rubocop:disable Rails/SkipsModelValidations
       end
     end
   end

--- a/spec/deleting/automate_deletion_returned_application_spec.rb
+++ b/spec/deleting/automate_deletion_returned_application_spec.rb
@@ -108,6 +108,131 @@ RSpec.describe Deleting::AutomateDeletion do
       end
     end
 
+    context 'when sent back 2 years ago, not injected into MAAT and has a superseded application' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let!(:crime_application) do
+        CrimeApplication.create!(
+          submitted_application:
+            JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('submitted_at' => Time.zone.local(2023, 8, 27).to_s),
+          status: :returned,
+          review_status: 'returned_to_provider',
+          returned_at: Time.zone.local(2023, 8, 28),
+          reviewed_at: Time.zone.local(2023, 8, 28)
+        )
+      end
+      let(:new_crime_application) do
+        CrimeApplication.create!(
+          submitted_application:
+            JSON.parse(LaaCrimeSchemas.fixture(1.0).read).merge('id' => SecureRandom.uuid,
+                                                                'submitted_at' => Time.zone.local(2023, 8, 29).to_s),
+          status: :returned,
+          review_status: 'returned_to_provider',
+          returned_at: Time.zone.local(2023, 8, 29),
+          reviewed_at: Time.zone.local(2023, 8, 29)
+        )
+      end
+      let(:new_entity_id) { new_crime_application.id }
+      let(:events) do
+        [
+          Applying::DraftCreated, Time.zone.local(2023, 8, 27), { entity_id:, entity_type:, business_reference: },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 27), { entity_id:, entity_type:, business_reference: },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 27), { entity_id:, entity_type:, business_reference: },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 27), { entity_id:, entity_type:, business_reference: },
+          Applying::Submitted, Time.zone.local(2023, 8, 27), { entity_id:, entity_type:, business_reference: },
+          Reviewing::SentBack, Time.zone.local(2023, 8, 28), { entity_id: entity_id, entity_type: entity_type,
+                                                              business_reference: business_reference,
+                                                              reason: 'duplicate_application' },
+          Applying::DraftCreated, Time.zone.local(2023, 8, 28), { entity_id: new_entity_id, entity_type: entity_type,
+                                                                  business_reference: business_reference },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 28), { entity_id: new_entity_id, entity_type: entity_type,
+                                                                  business_reference: business_reference },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 28), { entity_id: new_entity_id, entity_type: entity_type,
+                                                                  business_reference: business_reference },
+          Applying::DraftUpdated, Time.zone.local(2023, 8, 28), { entity_id: new_entity_id, entity_type: entity_type,
+                                                                  business_reference: business_reference },
+          Applying::Submitted, Time.zone.local(2023, 8, 29), { entity_id: new_entity_id, entity_type: entity_type,
+                                                               business_reference: business_reference },
+          Reviewing::SentBack, Time.zone.local(2023, 8, 29), { entity_id: new_entity_id, entity_type: entity_type,
+                                                              business_reference: business_reference,
+                                                              reason: 'evidence_issue' }
+        ]
+      end
+      let!(:deletable_entity) do
+        DeletableEntity.create!(business_reference: business_reference,
+                                review_deletion_at: Time.zone.local(2023, 8, 28))
+      end
+
+      before do
+        crime_application.superseded!
+        publish_events
+        automate_deletion.call
+      end
+
+      it_behaves_like 'an application with events'
+
+      it 'publishes a SoftDeleted event' do
+        soft_deleted_events = events_in_stream.of_type([Deleting::SoftDeleted]).to_a
+        expect(soft_deleted_events.count).to eq(1)
+        expect(soft_deleted_events.first.data).to eq(
+          {
+            entity_id: new_entity_id,
+            entity_type: entity_type,
+            business_reference: business_reference,
+            reason: Types::DeletionReason['retention_rule'],
+            deleted_by: 'system_automated'
+          }
+        )
+      end
+
+      it 'pushes the `review_deletion_at` timestamp on the read model back by two weeks' do
+        expect(deletable_entity.reload.review_deletion_at).to eq(current_date + 2.weeks)
+      end
+
+      it 'sets `soft_deleted_at` on both applications' do
+        expect(crime_application.reload.soft_deleted_at).to be_within(2.seconds).of(Time.zone.now)
+        expect(new_crime_application.reload.soft_deleted_at).to be_within(2.seconds).of(Time.zone.now)
+      end
+
+      context 'when two weeks have passed' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        before do
+          travel_to current_date + 2.weeks
+          automate_deletion.call
+        end
+
+        it 'does not publish another SoftDeleted event' do
+          expect(events_in_stream.of_type([Deleting::SoftDeleted]).count).to eq(1)
+        end
+
+        it 'publishes a HardDeleted event', pending: 'full implementation of hard deletion' do
+          hard_deleted_events = events_in_stream.of_type([Deleting::HardDeleted]).to_a
+          expect(hard_deleted_events.count).to eq(1)
+          expect(hard_deleted_events.first.data).to eq(
+            {
+              entity_id: new_entity_id,
+              entity_type: entity_type,
+              business_reference: business_reference,
+              deletion_entry_id: DeletionEntry.first.id,
+            }
+          )
+        end
+
+        it 'creates a deletion record', pending: 'full implementation of hard deletion' do
+          expect(DeletionEntry.first).to have_attributes(
+            {
+              record_id: new_entity_id,
+              record_type: Types::RecordType['application'],
+              business_reference: business_reference.to_s,
+              deleted_by: 'system_automated',
+              reason: Types::DeletionReason['retention_rule']
+            }
+          )
+        end
+
+        it 'removes deletable_entities record', pending: 'full implementation of hard deletion' do
+          expect(DeletableEntity.find_by(business_reference:)).to be_nil
+        end
+      end
+    end
+
     context 'when sent back 2 years ago, not injected into MAAT and migrated' do # rubocop:disable RSpec/MultipleMemoizedHelpers
       let(:submitted_at) { Time.zone.local(2023, 9, 3) }
       let(:returned_at) { Time.zone.local(2023, 9, 4) }


### PR DESCRIPTION
## Description of change
- fixes an issue where `soft_deleted_at` was not being set on superseded applications when soft-deleting

The impact of this is that superseded versions of an application would present PII in Review after soft-deletion.