### PR TITLE
Query MAAT ID on soft deletion

### DIFF
--- a/app/lib/maat/get_maat_id.rb
+++ b/app/lib/maat/get_maat_id.rb
@@ -2,7 +2,7 @@ module MAAT
   class GetMAATId
     USN_FORMAT = '/api/external/v1/crime-application/result/usn/%d'.freeze
 
-    def initialize(http_client: Maat::HttpClient.call)
+    def initialize(http_client: MAAT::HttpClient.call)
       @http_client = http_client
     end
 

--- a/deleting/lib/deleting/deletable.rb
+++ b/deleting/lib/deleting/deletable.rb
@@ -154,7 +154,7 @@ module Deleting
       return false unless returned?
       return false if active_drafts?
 
-      @deletion_at <= Time.zone.now && !injected_into_maat
+      @deletion_at <= Time.zone.now && !injected_into_maat?
     end
 
     def hard_deletable?
@@ -173,8 +173,12 @@ module Deleting
 
     private
 
-    def injected_into_maat
-      @maat_id.present?
+    def injected_into_maat?
+      return true if @maat_id.present?
+      return true if CrimeApplication.where(reference: @business_reference).map(&:maat_id).any?
+      return true if @decision_id.present? && Decision.find(@decision_id).maat_id.present?
+
+      MAAT::GetMAATId.new.by_usn(@business_reference).present?
     end
 
     def timestamp(event)

--- a/spec/deleting/automate_deletion_returned_application_spec.rb
+++ b/spec/deleting/automate_deletion_returned_application_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe Deleting::AutomateDeletion do
   let(:maat_id) { '987654321' }
   let(:event_stream) { "Deleting$#{business_reference}" }
   let(:current_date) { Time.zone.local(2025, 9, 6) }
+  let(:get_maat_id) { instance_double(MAAT::GetMAATId) }
 
   before do
+    allow(MAAT::GetMAATId).to receive(:new).and_return(get_maat_id)
     travel_to current_date
   end
 
@@ -39,11 +41,16 @@ RSpec.describe Deleting::AutomateDeletion do
       end
 
       before do
+        allow(get_maat_id).to receive(:by_usn).with(business_reference).and_return(nil)
         publish_events
         automate_deletion.call
       end
 
       it_behaves_like 'an application with events'
+
+      it 'queries the MAAT API to check for a MAAT ID' do
+        expect(get_maat_id).to have_received(:by_usn).with(business_reference)
+      end
 
       it 'publishes a SoftDeleted event' do
         soft_deleted_events = events_in_stream.of_type([Deleting::SoftDeleted]).to_a
@@ -162,12 +169,17 @@ RSpec.describe Deleting::AutomateDeletion do
       end
 
       before do
+        allow(get_maat_id).to receive(:by_usn).with(business_reference).and_return(nil)
         crime_application.superseded!
         publish_events
         automate_deletion.call
       end
 
       it_behaves_like 'an application with events'
+
+      it 'queries the MAAT API to check for a MAAT ID' do
+        expect(get_maat_id).to have_received(:by_usn).with(business_reference)
+      end
 
       it 'publishes a SoftDeleted event' do
         soft_deleted_events = events_in_stream.of_type([Deleting::SoftDeleted]).to_a
@@ -263,11 +275,16 @@ RSpec.describe Deleting::AutomateDeletion do
       end
 
       before do
+        allow(get_maat_id).to receive(:by_usn).with(business_reference).and_return(nil)
         publish_events
         automate_deletion.call
       end
 
       it_behaves_like 'an application with events'
+
+      it 'queries the MAAT API to check for a MAAT ID' do
+        expect(get_maat_id).to have_received(:by_usn).with(business_reference)
+      end
 
       it 'publishes a SoftDeleted event' do
         soft_deleted_events = events_in_stream.of_type([Deleting::SoftDeleted]).to_a


### PR DESCRIPTION
## Description of change
- updates `injected_into_maat?` in the `Deletable` aggregate to check the database and the MAAT API for a `maat_id` if it is not already known

## Notes for reviewer / how to test
This is a solution to the bug described in [this Slack conversation](https://mojdt.slack.com/archives/C05N1RXEU2E/p1762965324578839).