### PR TITLE
[CRIMAP-2078] only return initial applications for MAAT

### DIFF
--- a/app/services/operations/maat/get_application.rb
+++ b/app/services/operations/maat/get_application.rb
@@ -38,6 +38,7 @@ module Operations
       def record
         @record ||= CrimeApplication.active.find_by!(
           reference: reference,
+          application_type: Types::ApplicationType['initial'],
           review_status: [
             Types::ReviewApplicationStatus['ready_for_assessment'],
             Types::ReviewApplicationStatus['assessment_completed']

--- a/spec/api/datastore/v1/maat/applications_spec.rb
+++ b/spec/api/datastore/v1/maat/applications_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe 'get application ready for maat' do
       it_behaves_like 'an error that raises a 404 status code'
     end
 
+    context 'with a CIFC application' do
+      let(:submitted_application) do
+        super().deep_merge(
+          'application_type' => Types::ApplicationType['change_in_financial_circumstances']
+        )
+      end
+
+      before { api_request }
+
+      it_behaves_like 'an error that raises a 404 status code'
+    end
+
     context 'with an archived application' do
       before do
         application.touch(:archived_at) # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
## Description of change

Only return initial applications via the MAAT api. All other application types must be manually imported by the caseworker.

## Link to relevant ticket

https://dsdmoj.atlassian.net/browse/CRIMAPP-2078