### PR TITLE
Move decoding of object_key to API

### DIFF
--- a/app/api/datastore/v1/documents.rb
+++ b/app/api/datastore/v1/documents.rb
@@ -49,7 +49,7 @@ module Datastore
         route_param :object_key do
           delete do
             Operations::Documents::Delete.new(
-              object_key: params[:object_key]
+              object_key: Base64.strict_decode64(params[:object_key])
             ).call
           end
         end

--- a/app/services/operations/documents/delete.rb
+++ b/app/services/operations/documents/delete.rb
@@ -6,7 +6,7 @@ module Operations
       attr_accessor :object_key
 
       def initialize(object_key:)
-        @object_key = Base64.strict_decode64(object_key)
+        @object_key = object_key
       end
 
       def call

--- a/spec/api/datastore/v1/documents/delete_spec.rb
+++ b/spec/api/datastore/v1/documents/delete_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe 'delete a document' do
   let(:operation_class) { Operations::Documents::Delete }
   let(:stubbed_operation) { instance_double(operation_class, call: {}) }
 
-  let(:object_key) { 'MTIzL3h5ei9mb29iYXI=' }
+  let(:encoded_object_key) { 'MTIzL3h5ei9mb29iYXI=' }
+  let(:object_key) { '123/xyz/foobar' }
 
   before do
     allow(
@@ -14,7 +15,7 @@ RSpec.describe 'delete a document' do
 
   describe 'DELETE /documents/:object_key' do
     subject(:api_request) do
-      delete "/api/v1/documents/#{object_key}"
+      delete "/api/v1/documents/#{encoded_object_key}"
     end
 
     it_behaves_like 'a documents API endpoint'

--- a/spec/services/operations/documents/delete_spec.rb
+++ b/spec/services/operations/documents/delete_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 describe Operations::Documents::Delete do
   subject { described_class.new(object_key:) }
 
-  let(:object_key) { 'MTIzL2ZpbGVuYW1l' }
-  let(:decoded_object_key) { '123/filename' }
+  let(:object_key) { '123/filename' }
 
   describe '.new' do
     it 'decodes the object_key' do
-      expect(subject.object_key).to eq(decoded_object_key)
+      expect(subject.object_key).to eq(object_key)
     end
   end
 
@@ -24,12 +23,12 @@ describe Operations::Documents::Delete do
       end
 
       it 'performs the deletion of the object and logs the operation' do
-        expect(subject.call).to eq({ object_key: decoded_object_key })
+        expect(subject.call).to eq({ object_key: })
 
         expect(logger).to have_received(:info).with(
           [
             '[Operations::Documents::Delete]',
-            { object_key: decoded_object_key }.to_json
+            { object_key: }.to_json
           ].join(' ')
         )
       end
@@ -47,7 +46,7 @@ describe Operations::Documents::Delete do
         expect(logger).to have_received(:error).with(
           [
             '[Operations::Documents::Delete]',
-            { object_key: decoded_object_key, error: 'boom!' }.to_json
+            { object_key: object_key, error: 'boom!' }.to_json
           ].join(' ')
         )
       end


### PR DESCRIPTION
This is to allow the operation to be used with the original object key by other callers (Deleting in this instance)