### PR TITLE
[CRIMAPP-2002] Use stored_searchable_text in prod

### DIFF
--- a/config/kubernetes/production/config_map.yml
+++ b/config/kubernetes/production/config_map.yml
@@ -11,4 +11,4 @@ data:
   ENABLE_PROMETHEUS_EXPORTER: "true"
   # Datastore is accessed via local cluster networking (no SSL)
   DISABLE_HTTPS: enabled
-  USE_STORED_SEARCHABLE_TEXT: "false"
+  USE_STORED_SEARCHABLE_TEXT: "true"


### PR DESCRIPTION
## Description of change
- set `USE_STORED_SEARCHABLE_TEXT` to `"true"` in production so users can use the new search index

## Link to relevant ticket
[CRIMAPP-2002](https://dsdmoj.atlassian.net/browse/CRIMAPP-2002)

[CRIMAPP-2002]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ