### PR TITLE
Bump net-imap to 0.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ GEM
       mustermann (>= 1.0.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -424,7 +424,7 @@ GEM
     stackprof (0.2.26)
     stringio (3.2.0)
     thor (1.5.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
## Description of change
- resolve high and critical security vulnerabilities by upgrading `net-imap` to v0.6.4

This was found by the SCA workflow (`dependency-check` action). Interestingly, Dependabot did not raise an upgrade PR in this repository, but it did in the other Crime Apply/Review repositories.

Aims to resolve:
https://github.com/ministryofjustice/laa-criminal-applications-datastore/security/code-scanning/15
https://github.com/ministryofjustice/laa-criminal-applications-datastore/security/code-scanning/13
https://github.com/ministryofjustice/laa-criminal-applications-datastore/security/code-scanning/14
https://github.com/ministryofjustice/laa-criminal-applications-datastore/security/code-scanning/16
https://github.com/ministryofjustice/laa-criminal-applications-datastore/security/code-scanning/17