### PR TITLE
[CRIMAPP-2222] Copy MAAT translators from Review

### DIFF
--- a/app/lib/maat/translators/assessment_rules_translator.rb
+++ b/app/lib/maat/translators/assessment_rules_translator.rb
@@ -1,0 +1,44 @@
+module MAAT
+  module Translators
+    class AssessmentRulesTranslator
+      def initialize(maat_record:)
+        @maat_record = maat_record
+      end
+
+      def translate
+        return nil unless assessment_rules
+
+        Types::AssessmentRules[assessment_rules]
+      end
+
+      class << self
+        def translate(maat_record:)
+          new(maat_record:).translate
+        end
+      end
+
+      private
+
+      attr_reader :maat_record
+
+      def assessment_rules
+        case maat_record.case_type
+        when 'APPEAL CC'
+          'appeal_to_crown_court'
+        when 'COMMITAL'
+          'committal_for_sentence'
+        when 'EITHER WAY'
+          infer_either_way_assessment_rules
+        when 'INDICTABLE', 'CC ALREADY'
+          'crown_court'
+        when 'SUMMARY ONLY'
+          'magistrates_court'
+        end
+      end
+
+      def infer_either_way_assessment_rules
+        maat_record.cc_rep_decision ? 'crown_court' : 'magistrates_court'
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/base_translator.rb
+++ b/app/lib/maat/translators/base_translator.rb
@@ -1,0 +1,26 @@
+module MAAT
+  module Translators
+    class BaseTranslator
+      def initialize(original:)
+        @original = original
+      end
+
+      class << self
+        def translate(original)
+          new(original:).translate
+        end
+      end
+
+      # :nocov:
+      def translate
+        raise 'implement in subclasses'
+      end
+      # :nocov:
+      #
+
+      private
+
+      attr_reader :original
+    end
+  end
+end

--- a/app/lib/maat/translators/crown_court_decision_translator.rb
+++ b/app/lib/maat/translators/crown_court_decision_translator.rb
@@ -1,0 +1,22 @@
+module MAAT
+  module Translators
+    class CrownCourtDecisionTranslator < BaseTranslator
+      def translate
+        return nil if funding_decision.blank?
+
+        Types::FundingDecision[funding_decision]
+      end
+
+      private
+
+      def funding_decision
+        case original
+        when /Granted/
+          'granted'
+        when /Refused|Failed/
+          'refused'
+        end
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/funding_decision_translator.rb
+++ b/app/lib/maat/translators/funding_decision_translator.rb
@@ -1,0 +1,22 @@
+module MAAT
+  module Translators
+    class FundingDecisionTranslator < BaseTranslator
+      def translate
+        return nil if funding_decision.blank?
+
+        Types::FundingDecision[funding_decision]
+      end
+
+      private
+
+      def funding_decision
+        case original
+        when /PASS|GRANTED|FULL/
+          'granted'
+        when /INEL|FAIL/
+          'refused'
+        end
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/interests_of_justice_result_translator.rb
+++ b/app/lib/maat/translators/interests_of_justice_result_translator.rb
@@ -1,0 +1,22 @@
+module MAAT
+  module Translators
+    class InterestsOfJusticeResultTranslator < BaseTranslator
+      def translate
+        return nil if original.blank?
+
+        Types::TestResult[means_result]
+      end
+
+      private
+
+      def means_result
+        case original
+        when /PASS/
+          'passed'
+        when /FAIL/
+          'failed'
+        end
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/interests_of_justice_translator.rb
+++ b/app/lib/maat/translators/interests_of_justice_translator.rb
@@ -1,0 +1,47 @@
+module MAAT
+  module Translators
+    class InterestsOfJusticeTranslator
+      def initialize(maat_record:)
+        @maat_record = maat_record
+      end
+
+      class << self
+        def translate(maat_record:)
+          new(maat_record:).translate
+        end
+      end
+
+      def translate
+        return nil unless result
+
+        LaaCrimeSchemas::Structs::TestResult.new(
+          result:, assessed_by:, assessed_on:, details:
+        )
+      end
+
+      private
+
+      def assessed_on
+        maat_record.app_created_date
+      end
+
+      def assessed_by
+        maat_record.ioj_assessor_name
+      end
+
+      def details
+        maat_record.ioj_reason
+      end
+
+      def result
+        InterestsOfJusticeResultTranslator.translate(maat_result)
+      end
+
+      def maat_result
+        maat_record.ioj_appeal_result.presence || maat_record.ioj_result
+      end
+
+      attr_reader :maat_record
+    end
+  end
+end

--- a/app/lib/maat/translators/means_result_translator.rb
+++ b/app/lib/maat/translators/means_result_translator.rb
@@ -1,0 +1,44 @@
+module MAAT
+  module Translators
+    class MeansResultTranslator
+      def initialize(maat_record:)
+        @maat_record = maat_record
+      end
+
+      def translate
+        return nil unless means_result
+
+        Types::TestResult[means_result]
+      end
+
+      class << self
+        def translate(maat_record:)
+          new(maat_record:).translate
+        end
+      end
+
+      private
+
+      attr_reader :maat_record
+
+      def means_result
+        case maat_record.means_result
+        when /PASS/
+          'passed'
+        when /FAIL/
+          crown_court_trial? ? 'passed_with_contribution' : 'failed'
+        when /INEL/
+          'failed'
+        end
+      end
+
+      def crown_court_trial?
+        assessment_rules == Types::AssessmentRules['crown_court']
+      end
+
+      def assessment_rules
+        AssessmentRulesTranslator.new(maat_record:).translate
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/means_translator.rb
+++ b/app/lib/maat/translators/means_translator.rb
@@ -1,0 +1,62 @@
+module MAAT
+  module Translators
+    class MeansTranslator
+      def initialize(maat_record:)
+        @maat_record = maat_record
+      end
+
+      def translate
+        return nil unless result
+
+        LaaCrimeSchemas::Structs::TestResult.new(
+          result:, assessed_by:, assessed_on:
+        )
+      end
+
+      class << self
+        def translate(maat_record:)
+          new(maat_record:).translate
+        end
+      end
+
+      private
+
+      attr_reader :maat_record
+
+      def assessed_on
+        if passport_result_most_recent?
+          maat_record.date_passport_created
+        else
+          maat_record.date_means_created
+        end
+      end
+
+      def assessed_by
+        if passport_result_most_recent?
+          maat_record.passport_assessor_name
+        else
+          maat_record.means_assessor_name
+        end
+      end
+
+      def result
+        return passport_result if passport_result_most_recent?
+
+        MeansResultTranslator.translate(maat_record:)
+      end
+
+      def passport_result
+        PassportMeansResultTranslator.translate(
+          maat_record.passport_result
+        )
+      end
+
+      def passport_result_most_recent?
+        return false if maat_record.date_passport_created.blank?
+        return true if maat_record.date_means_created.blank?
+
+        maat_record.date_passport_created > maat_record.date_means_created
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/passport_means_result_translator.rb
+++ b/app/lib/maat/translators/passport_means_result_translator.rb
@@ -1,0 +1,20 @@
+module MAAT
+  module Translators
+    class PassportMeansResultTranslator < BaseTranslator
+      def translate
+        return nil unless means_result
+
+        Types::TestResult[means_result]
+      end
+
+      private
+
+      def means_result
+        case original
+        when /PASS/
+          'passed'
+        end
+      end
+    end
+  end
+end

--- a/app/lib/maat/translators/record_translator.rb
+++ b/app/lib/maat/translators/record_translator.rb
@@ -1,0 +1,62 @@
+module MAAT
+  module Translators
+    class RecordTranslator
+      def initialize(maat_record:)
+        @maat_record = maat_record
+      end
+
+      class << self
+        def translate(maat_record)
+          new(maat_record:).translate
+        end
+      end
+
+      def translate
+        LaaCrimeSchemas::Structs::Decision.new(
+          maat_id:, case_id:, reference:, interests_of_justice:,
+          means:, funding_decision:, assessment_rules:
+        )
+      end
+
+      private
+
+      attr_reader :maat_record
+
+      delegate :case_id, to: :maat_record
+
+      def maat_id
+        maat_record.maat_ref
+      end
+
+      def reference
+        maat_record.usn
+      end
+
+      def interests_of_justice
+        InterestsOfJusticeTranslator.translate(maat_record:)
+      end
+
+      def means
+        MeansTranslator.translate(maat_record:)
+      end
+
+      def assessment_rules
+        AssessmentRulesTranslator.translate(maat_record:)
+      end
+
+      # The MAAT API can return partially completed results. During reassessment,
+      # the MAAT API maintains the previous funding decision until the means
+      # assessment is completed. Therefore, funding decisions that exist without
+      # a corresponding means result should be ignored.
+      def funding_decision
+        return if means.blank?
+
+        if maat_record.cc_rep_decision.present?
+          CrownCourtDecisionTranslator.translate(maat_record.cc_rep_decision)
+        else
+          FundingDecisionTranslator.translate(maat_record.funding_decision)
+        end
+      end
+    end
+  end
+end

--- a/deciding/lib/deciding/overall_result_calculator.rb
+++ b/deciding/lib/deciding/overall_result_calculator.rb
@@ -1,0 +1,67 @@
+module Deciding
+  class OverallResultCalculator
+    def initialize(decision)
+      @decision = decision
+    end
+
+    def calculate
+      return unless funding_decision
+
+      Types::OverallResult[
+        [funding_decision, qualification].compact.join('_')
+      ]
+    end
+
+    private
+
+    attr_reader :decision
+
+    def qualification
+      return refusal_qualification if refused?
+
+      grant_qualification if granted?
+    end
+
+    def refusal_qualification
+      return 'ineligible' if ineligible?
+      return 'failed_ioj_and_means' if failed_means? && failed_ioj?
+      return 'failed_ioj' if failed_ioj?
+
+      'failed_means' if failed_means?
+    end
+
+    def grant_qualification
+      return 'failed_means' if failed_means?
+
+      'with_contribution' if with_contribution?
+    end
+
+    delegate :funding_decision, to: :decision
+
+    def failed_means?
+      decision.means&.result == 'failed'
+    end
+
+    def ineligible?
+      return false unless decision.assessment_rules == 'crown_court'
+
+      failed_means?
+    end
+
+    def granted?
+      funding_decision == 'granted'
+    end
+
+    def refused?
+      funding_decision == 'refused'
+    end
+
+    def with_contribution?
+      decision.means&.result == 'passed_with_contribution'
+    end
+
+    def failed_ioj?
+      decision.interests_of_justice&.result == 'failed'
+    end
+  end
+end

--- a/spec/deciding/overall_result_calculator_spec.rb
+++ b/spec/deciding/overall_result_calculator_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Deciding::OverallResultCalculator do
+  describe '#calculate' do
+    subject do
+      described_class.new(decision).calculate
+    end
+
+    let(:decision) do
+      instance_double(
+        LaaCrimeSchemas::Structs::Decision,
+        means: instance_double(
+          LaaCrimeSchemas::Structs::TestResult, result: means_result
+        ),
+        assessment_rules: assessment_rules,
+        funding_decision: funding_decision,
+        interests_of_justice: instance_double(
+          LaaCrimeSchemas::Structs::TestResult, result: ioj_result
+        )
+      )
+    end
+
+    context 'when funding is granted' do
+      let(:funding_decision) { 'granted' }
+      let(:assessment_rules) { 'magistrates_court' }
+
+      context 'when means test is failed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'failed' }
+
+        it { is_expected.to eq('granted_failed_means') }
+      end
+
+      context 'when means test passed with contribution' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed_with_contribution' }
+
+        it { is_expected.to eq('granted_with_contribution') }
+      end
+
+      context 'when means test fully passed' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed' }
+
+        it { is_expected.to eq('granted') }
+      end
+    end
+
+    context 'when funding is refused and `assessment_rules` "crown_court"' do
+      let(:ioj_result) { 'passed' }
+      let(:funding_decision) { 'refused' }
+      let(:assessment_rules) { 'crown_court' }
+
+      context 'when the means test failed' do
+        let(:means_result) { 'failed' }
+
+        it { is_expected.to eq('refused_ineligible') }
+      end
+
+      context 'when both tests pass' do
+        let(:ioj_result) { 'passed' }
+        let(:means_result) { 'passed' }
+
+        it { is_expected.to eq('refused') }
+      end
+    end
+  end
+end

--- a/spec/lib/maat/translators/assessment_rules_translator_spec.rb
+++ b/spec/lib/maat/translators/assessment_rules_translator_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::AssessmentRulesTranslator do
+  expected_translations = [
+    { case_type: 'INDICTABLE' }, 'crown_court',
+    { case_type: 'SUMMARY ONLY' }, 'magistrates_court',
+    { case_type: 'COMMITAL' }, 'committal_for_sentence',
+    { case_type: 'APPEAL CC' }, 'appeal_to_crown_court',
+    { case_type: 'CC ALREADY' }, 'crown_court',
+    { case_type: 'EITHER WAY' }, 'magistrates_court',
+    { case_type: 'EITHER WAY', cc_rep_decision: 'Granted' }, 'crown_court',
+    { case_type: 'EITHER WAY', cc_rep_decision: 'nil' }, 'crown_court',
+  ]
+
+  it_behaves_like 'a MAAT decision value translator', expected_translations
+end

--- a/spec/lib/maat/translators/crown_court_decision_translator_spec.rb
+++ b/spec/lib/maat/translators/crown_court_decision_translator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::CrownCourtDecisionTranslator do
+  expected_translations = [
+    'Granted - Passed Means Test', 'granted',
+    'Granted - Failed Means Test', 'granted',
+    'Refused - Ineligible', 'refused',
+    'Failed - CfS Failed Means Test', 'refused'
+  ].freeze
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/lib/maat/translators/funding_decision_translator_spec.rb
+++ b/spec/lib/maat/translators/funding_decision_translator_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::FundingDecisionTranslator do
+  expected_translations = %w[
+    PASS granted
+    FAIL refused
+    INEL refused
+    FULL granted
+    GRANTED granted
+    FAILMEANS refused
+    FAILIOJ refused
+    FAILMEIOJ refused
+  ]
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/lib/maat/translators/interests_of_justice_translator_spec.rb
+++ b/spec/lib/maat/translators/interests_of_justice_translator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::InterestsOfJusticeTranslator do
+  let(:maat_record) do
+    MAAT::Record.new(
+      maat_ref: 6_000_001,
+      ioj_reason: 'because',
+      ioj_assessor_name: 'Ken',
+      ioj_result: ioj_result,
+      app_created_date: DateTime.new(2024, 12, 12, 12),
+      ioj_appeal_result: ioj_appeal_result
+    )
+  end
+
+  let(:ioj_appeal_result) { nil }
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_record:) }
+
+    context 'when IoJ result is nil' do
+      let(:ioj_result) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when IoJ result set' do
+      let(:ioj_result) { 'FAIL' }
+
+      it 'returns the translated result as a hash' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Ken',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          details: 'because',
+          result: 'failed'
+        )
+      end
+
+      context 'when IoJ appeal result present' do
+        let(:ioj_appeal_result) { 'PASS' }
+
+        it 'uses the appeal result' do
+          expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+            assessed_by: 'Ken',
+            assessed_on: DateTime.new(2024, 12, 12, 12),
+            details: 'because',
+            result: 'passed'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/maat/translators/means_result_translator_spec.rb
+++ b/spec/lib/maat/translators/means_result_translator_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::MeansResultTranslator do
+  expected_translations = [
+    { means_result: 'FAIL' }, 'failed',
+    { means_result: 'FAIL', case_type: 'COMMITAL' }, 'failed',
+    { means_result: 'FAIL', case_type: 'APPEAL CC' }, 'failed',
+    { means_result: 'FAIL', case_type: 'CC ALREADY' }, 'passed_with_contribution',
+    { means_result: 'FAIL', case_type: 'INDICTABLE' }, 'passed_with_contribution',
+    { means_result: 'FULL' }, nil,
+    { means_result: 'HARDSHIP APPLICATION' }, nil,
+    { means_result: 'INEL' }, 'failed',
+    { means_result: 'INEL' }, 'failed',
+    { means_result: 'PASS' }, 'passed',
+  ]
+
+  it_behaves_like 'a MAAT decision value translator', expected_translations
+end

--- a/spec/lib/maat/translators/means_translator_spec.rb
+++ b/spec/lib/maat/translators/means_translator_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::MeansTranslator do
+  let(:maat_record) { MAAT::Record.new }
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_record:) }
+
+    context 'when the means result and passport result are both nil' do
+      let(:maat_record) { MAAT::Record.new(maat_ref: 6_000_001) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when only the passport result is present' do
+      let(:maat_record) do
+        MAAT::Record.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 13)
+        )
+      end
+
+      it 'returns the passporting result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Pam',
+          assessed_on: DateTime.new(2024, 12, 12, 13),
+          result: 'passed'
+        )
+      end
+    end
+
+    context 'when only the passport result is present and the result undetermined' do
+      let(:maat_record) do
+        MAAT::Record.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'FAIL',
+          date_passport_created: DateTime.new(2024, 12, 12, 13)
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when only the means result is present' do
+      let(:maat_record) do
+        MAAT::Record.new(
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          case_type: case_type,
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      let(:case_type) { 'SUMMARY_ONLY' }
+
+      it 'returns the means result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Kit',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          result: 'failed'
+        )
+      end
+
+      context 'when a Crown Court decision' do
+        let(:case_type) { 'INDICTABLE' }
+
+        it 'returns the Crown Court court means result' do
+          expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+            assessed_by: 'Kit',
+            assessed_on: DateTime.new(2024, 12, 12, 12),
+            result: 'passed_with_contribution'
+          )
+        end
+      end
+    end
+
+    context 'when both means and passport results are present' do
+      let(:maat_record) do
+        MAAT::Record.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 13),
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      it 'uses the most recent' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Pam',
+          assessed_on: DateTime.new(2024, 12, 12, 13),
+          result: 'passed'
+        )
+      end
+    end
+
+    context 'when means and passport results have the same timestamp' do
+      let(:maat_record) do
+        MAAT::Record.new(
+          passport_assessor_name: 'Pam',
+          passport_result: 'PASS',
+          date_passport_created: DateTime.new(2024, 12, 12, 12),
+          means_assessor_name: 'Kit',
+          means_result: 'FAIL',
+          date_means_created: DateTime.new(2024, 12, 12, 12)
+        )
+      end
+
+      it 'returns the means result details' do
+        expect(translate).to eq LaaCrimeSchemas::Structs::TestResult.new(
+          assessed_by: 'Kit',
+          assessed_on: DateTime.new(2024, 12, 12, 12),
+          result: 'failed'
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/maat/translators/passport_means_result_translator_spec.rb
+++ b/spec/lib/maat/translators/passport_means_result_translator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::PassportMeansResultTranslator do
+  expected_translations = [
+    'PASS', 'passed',
+    'TEMP', nil,
+    'FAIL CONTINUE', nil,
+    'FAIL', nil
+  ]
+
+  it_behaves_like 'a MAAT value translator', expected_translations
+end

--- a/spec/lib/maat/translators/record_translator_spec.rb
+++ b/spec/lib/maat/translators/record_translator_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+
+RSpec.describe MAAT::Translators::RecordTranslator do
+  let(:maat_record) { MAAT::Record.new(funding_decision: nil) }
+
+  let(:translated_means) do
+    LaaCrimeSchemas::Structs::TestResult.new(
+      result: 'passed',
+      assessed_by: 'Ken',
+      assessed_on: '2024-12-12'
+    )
+  end
+
+  describe '.translate' do
+    subject(:translate) { described_class.translate(maat_record) }
+
+    let(:maat_record) { MAAT::Record.new }
+
+    it { is_expected.to be_a LaaCrimeSchemas::Structs::Decision }
+
+    describe '#funding_decision' do
+      subject(:funding_decision) { translate.funding_decision }
+
+      before do
+        allow(MAAT::Translators::MeansTranslator).to receive(:translate) { translated_means }
+      end
+
+      context 'when not decided' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when funding decision exists' do
+        let(:maat_record) do
+          MAAT::Record.new(funding_decision: 'FAILIOJ')
+        end
+
+        it { is_expected.to eq 'refused' }
+      end
+
+      context 'when funding decision exists but means is empty' do
+        let(:maat_record) do
+          MAAT::Record.new(funding_decision: 'FAILIOJ')
+        end
+
+        let(:translated_means) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'when a crown court decision exists' do
+        let(:maat_record) do
+          MAAT::Record.new(cc_rep_decision: 'Granted - Passported')
+        end
+
+        it { is_expected.to eq 'granted' }
+      end
+
+      context 'when both a crown court and funding decision exists' do
+        let(:maat_record) do
+          MAAT::Record.new(
+            funding_decision: 'FAILMEIOJ',
+            cc_rep_decision: 'Granted - Passported'
+          )
+        end
+
+        it 'returns the crown court decision' do
+          expect(funding_decision).to eq 'granted'
+        end
+      end
+    end
+
+    describe '#case_id' do
+      subject(:case_id) { translate.case_id }
+
+      context 'when case_id nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when case_id is set' do
+        let(:maat_record) { MAAT::Record.new(case_id: 'AbD123') }
+
+        it { is_expected.to eq 'AbD123' }
+      end
+    end
+
+    describe '#maat_id' do
+      subject(:maat_id) { translate.maat_id }
+
+      context 'when maat_ref nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when maat_ref is set' do
+        let(:maat_record) { MAAT::Record.new(maat_ref: 6_090_910) }
+
+        it { is_expected.to be 6_090_910 }
+      end
+    end
+
+    describe '#reference' do
+      subject(:reference) { translate.reference }
+
+      context 'when usn nil' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'when usn is set' do
+        let(:maat_record) { MAAT::Record.new(usn: 6_090_910) }
+
+        it { is_expected.to be 6_090_910 }
+      end
+    end
+
+    describe '#means' do
+      subject(:means) { translate.means }
+
+      before do
+        allow(MAAT::Translators::MeansTranslator).to receive(:translate)
+          .with(maat_record:) { translated_means }
+      end
+
+      it { is_expected.to eq(translated_means) }
+    end
+
+    describe '#interests_of_justice' do
+      subject(:interests_of_justice) { translate.interests_of_justice }
+
+      let(:translated_interests_of_justice) do
+        LaaCrimeSchemas::Structs::TestResult.new(
+          result: 'failed',
+          assessed_by: 'Jo',
+          assessed_on: '2024-12-11'
+        )
+      end
+
+      before do
+        allow(MAAT::Translators::InterestsOfJusticeTranslator).to receive(:translate)
+          .with(maat_record:) { translated_interests_of_justice }
+      end
+
+      it { is_expected.to eq(translated_interests_of_justice) }
+    end
+
+    describe '#assessment_rules' do
+      subject(:assessment_rules) { translate.assessment_rules }
+
+      before do
+        allow(MAAT::Translators::AssessmentRulesTranslator).to receive(:translate)
+          .and_return('committal_for_sentence')
+      end
+
+      it 'returns the translated rules' do
+        expect(assessment_rules).to eq('committal_for_sentence')
+
+        expect(MAAT::Translators::AssessmentRulesTranslator).to have_received(:translate)
+          .with(maat_record:)
+      end
+    end
+  end
+end

--- a/spec/shared_examples/a_maat_value_translator.rb
+++ b/spec/shared_examples/a_maat_value_translator.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples 'a MAAT value translator' do |expected_translations|
+  expected_translations.each_slice(2).each do |original, expected|
+    it "#{original} is translated to #{expected}" do
+      expect(described_class.translate(original)).to eq(expected)
+    end
+  end
+end
+
+RSpec.shared_examples 'a MAAT decision value translator' do |expected_translations|
+  expected_translations.each_slice(2).each do |decision_attr, expected|
+    context "when #{decision_attr.each_pair.map { |k, v| "#{k} is #{v}" }.to_sentence}" do
+      it "is translated to #{expected}" do
+        maat_record = MAAT::Record.new(**decision_attr)
+        expect(described_class.translate(maat_record:)).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
- copy the MAAT translators from Review https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/777
- copy the overall decision calculator from Review https://github.com/ministryofjustice/laa-review-criminal-legal-aid/pull/805

The above code is duplicated for the time being, but is necessary to recalculate updated decision outcomes when checking for changes that have been made to refused applications in MAAT since their completion as part of the 3-year data retention process.

## Link to relevant ticket
[CRIMAPP-2222](https://dsdmoj.atlassian.net/browse/CRIMAPP-2222)

[CRIMAPP-2222]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ