### PR TITLE
Register deletion log collector

### DIFF
--- a/app/lib/prometheus_metrics/configuration.rb
+++ b/app/lib/prometheus_metrics/configuration.rb
@@ -6,6 +6,7 @@ module PrometheusMetrics
     DEFAULT_PREFIX = 'ruby_'.freeze
     CUSTOM_COLLECTORS = [
       # Add custom collector classes here
+      Collectors::DeletionLogCollector
     ].freeze
 
     # :nocov:


### PR DESCRIPTION
## Description of change
- register the new `DeletionLogCollector` with Prometheus

This is most likely why no metrics are being captured from the new collector: [Slack alert](https://mojdt.slack.com/archives/C056U956ESH/p1779874493262059)