### PR TITLE
[CRIMAPP-2222] fix to sync maat record

### DIFF
--- a/deleting/lib/deleting/commands/sync_maat_record.rb
+++ b/deleting/lib/deleting/commands/sync_maat_record.rb
@@ -15,7 +15,7 @@ module Deleting
           # They may have a maat_id provided by the Deleting::ApplicationMigrated event
           # Otherwise we need to fetch the record by USN
           if deletable.decision_ids.present?
-            deletable.decision_ids.each { |id| sync_by_maat_id(deletable, maat_client, id) }
+            sync_by_decision_ids(deletable, maat_client)
           elsif deletable.maat_ids.present?
             deletable.maat_ids.each { |id| sync_by_maat_id(deletable, maat_client, id) }
           else
@@ -26,11 +26,40 @@ module Deleting
 
       private
 
-      def sync_by_maat_id(deletable, maat_client, decision_id)
-        maat_record = maat_client.by_maat_id!(decision_id)
-        process(deletable, decision_id:, maat_record:)
+      def sync_by_maat_id(deletable, maat_client, maat_id)
+        maat_record = maat_client.by_maat_id!(maat_id)
+        process(deletable, decision_id: maat_id, maat_record: maat_record)
       rescue MAAT::RecordNotFound => e
         Rails.error.report(e)
+      end
+
+      def sync_by_decision_ids(deletable, maat_client)
+        deletable.decision_ids.each do |decision_id|
+          decision = Decision.find_by(id: decision_id)
+          maat_id = resolve_maat_id(decision, decision_id)
+          next unless maat_id
+
+          maat_record = maat_client.by_maat_id!(maat_id)
+          process(deletable, decision_id:, maat_record:)
+        rescue MAAT::RecordNotFound => e
+          Rails.error.report(e)
+        end
+      end
+
+      def resolve_maat_id(decision, decision_id)
+        unless decision
+          Rails.logger.warn("SyncMAATRecord: Decision not found for id #{decision_id} " \
+                            "(reference: #{@business_reference})")
+          return nil
+        end
+
+        unless decision.maat_id
+          Rails.logger.info("SyncMAATRecord: Decision #{decision_id} has no maat_id, skipping " \
+                            "(reference: #{@business_reference})")
+          return nil
+        end
+
+        decision.maat_id
       end
 
       def sync_by_usn(deletable, maat_client)

--- a/spec/deleting/automate_deletion_refused_application_spec.rb
+++ b/spec/deleting/automate_deletion_refused_application_spec.rb
@@ -139,10 +139,13 @@ RSpec.describe Deleting::AutomateDeletion do
         DeletableEntity.create!(business_reference: business_reference,
                                 review_deletion_at: Time.zone.local(2022, 9, 4))
       end
-      let(:decision_id) { 9_874_622 }
+      let(:decision_id) { SecureRandom.uuid }
+      let(:decision_maat_id) { 9_874_622 }
       let(:maat_record) { nil }
 
       before do
+        Decision.create!(id: decision_id, crime_application: crime_application, maat_id: decision_maat_id,
+                         funding_decision: 'refused')
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
@@ -171,7 +174,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'without new updates in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'FAIL',
             ioj_assessor_name: 'Jo Bloggs',
@@ -184,7 +187,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'does not publish a MaatRecordUpdated event' do
@@ -266,7 +269,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'with a granted IOJ appeal and granted funding decision in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'FAIL',
             ioj_assessor_name: 'Jo Bloggs',
@@ -282,7 +285,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'publishes a MaatRecordUpdated event' do
@@ -328,7 +331,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'with a refused IOJ appeal and unchanged funding decision in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'FAIL',
             ioj_assessor_name: 'Jo Bloggs',
@@ -344,7 +347,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'publishes a MaatRecordUpdated event' do
@@ -396,10 +399,13 @@ RSpec.describe Deleting::AutomateDeletion do
         DeletableEntity.create!(business_reference: business_reference,
                                 review_deletion_at: Time.zone.local(2022, 9, 4))
       end
-      let(:decision_id) { 9_874_622 }
+      let(:decision_id) { SecureRandom.uuid }
+      let(:decision_maat_id) { 9_874_622 }
       let(:maat_record) { nil }
 
       before do
+        Decision.create!(id: decision_id, crime_application: crime_application, maat_id: decision_maat_id,
+                         funding_decision: 'refused')
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
@@ -428,7 +434,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'without new updates in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'PASS',
             ioj_assessor_name: 'Jo Bloggs',
@@ -441,7 +447,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'does not publish a MaatRecordUpdated event' do
@@ -523,7 +529,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'with a granted CC decision and passed means in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'PASS',
             ioj_assessor_name: 'Jo Bloggs',
@@ -538,7 +544,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'publishes a MaatRecordUpdated event' do
@@ -584,7 +590,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'with a passed means reassessment in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'PASS',
             ioj_assessor_name: 'Jo Bloggs',
@@ -599,7 +605,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'publishes a MaatRecordUpdated event' do
@@ -645,7 +651,7 @@ RSpec.describe Deleting::AutomateDeletion do
       context 'with a refused means reassessment in MAAT' do
         let(:maat_record) do
           MAAT::Record.new(
-            maat_ref: decision_id,
+            maat_ref: decision_maat_id,
             usn: business_reference,
             ioj_result: 'PASS',
             ioj_assessor_name: 'Jo Bloggs',
@@ -660,7 +666,7 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'calls MAAT' do
-          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_id).once
+          expect(maat_get_record).to have_received(:by_maat_id!).with(decision_maat_id).once
         end
 
         it 'publishes a MaatRecordUpdated event' do

--- a/spec/deleting/commands/sync_maat_record_spec.rb
+++ b/spec/deleting/commands/sync_maat_record_spec.rb
@@ -134,4 +134,84 @@ RSpec.describe Deleting::Commands::SyncMAATRecord do
       expect(maat_get_record).to have_received(:by_maat_id!).with(7_654_321)
     end
   end
+
+  context 'when the application has decision_ids but the Decision record does not exist' do
+    let(:non_existent_decision_id) { SecureRandom.uuid }
+
+    let(:events) do
+      [
+        Applying::Submitted, Time.zone.local(2022, 9, 1),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        },
+        Deciding::Decided, Time.zone.local(2022, 9, 4),
+        {
+          entity_id: entity_id,
+          entity_type: entity_type,
+          business_reference: business_reference,
+          decision_id: non_existent_decision_id,
+          overall_decision: 'refused'
+        },
+        Reviewing::Completed, Time.zone.local(2022, 9, 4),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        }
+      ]
+    end
+
+    it 'logs a warning and does not call the MAAT API' do
+      allow(Rails.logger).to receive(:warn)
+      allow(maat_get_record).to receive(:by_maat_id!)
+
+      sync_maat_record.call
+
+      expect(Rails.logger).to have_received(:warn).with(/Decision not found for id #{non_existent_decision_id}/)
+      expect(maat_get_record).not_to have_received(:by_maat_id!)
+    end
+  end
+
+  context 'when the application has decision_ids but the Decision has no maat_id' do
+    let(:decision_without_maat_id) do
+      Decision.create!(crime_application: crime_application, maat_id: nil, funding_decision: 'refused')
+    end
+
+    let(:events) do
+      [
+        Applying::Submitted, Time.zone.local(2022, 9, 1),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        },
+        Deciding::Decided, Time.zone.local(2022, 9, 4),
+        {
+          entity_id: entity_id,
+          entity_type: entity_type,
+          business_reference: business_reference,
+          decision_id: decision_without_maat_id.id,
+          overall_decision: 'refused'
+        },
+        Reviewing::Completed, Time.zone.local(2022, 9, 4),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        }
+      ]
+    end
+
+    it 'logs info and does not call the MAAT API' do
+      allow(Rails.logger).to receive(:info)
+      allow(maat_get_record).to receive(:by_maat_id!)
+
+      sync_maat_record.call
+
+      expect(Rails.logger).to have_received(:info).with(/has no maat_id, skipping/)
+      expect(maat_get_record).not_to have_received(:by_maat_id!)
+    end
+  end
 end

--- a/spec/deleting/commands/sync_maat_record_spec.rb
+++ b/spec/deleting/commands/sync_maat_record_spec.rb
@@ -64,4 +64,74 @@ RSpec.describe Deleting::Commands::SyncMAATRecord do
       expect(events_in_stream.of_type([Deciding::DecisionUpdated]).count).to eq(0)
     end
   end
+
+  context 'when the application has maat_ids' do
+    let(:events) do
+      [
+        Deleting::ApplicationMigrated, Time.zone.local(2022, 9, 4),
+        {
+          entity_id: entity_id,
+          entity_type: entity_type,
+          business_reference: business_reference,
+          maat_id: 6_563_959,
+          decision_id: nil,
+          overall_decision: nil,
+          submitted_at: Time.zone.local(2022, 9, 1),
+          returned_at: nil,
+          reviewed_at: Time.zone.local(2022, 9, 4),
+          last_updated_at: Time.zone.local(2022, 9, 4),
+          review_status: 'assessment_completed'
+        }
+      ]
+    end
+
+    it 'calls the MAAT API with the numeric maat_id' do
+      allow(maat_get_record).to receive(:by_maat_id!).and_raise(MAAT::RecordNotFound)
+      allow(Rails.error).to receive(:report)
+
+      sync_maat_record.call
+
+      expect(maat_get_record).to have_received(:by_maat_id!).with(6_563_959)
+    end
+  end
+
+  context 'when the application has decision_ids but no maat_ids' do
+    let(:decision) do
+      Decision.create!(crime_application: crime_application, maat_id: 7_654_321, funding_decision: 'refused')
+    end
+
+    let(:events) do
+      [
+        Applying::Submitted, Time.zone.local(2022, 9, 1),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        },
+        Deciding::Decided, Time.zone.local(2022, 9, 4),
+        {
+          entity_id: entity_id,
+          entity_type: entity_type,
+          business_reference: business_reference,
+          decision_id: decision.id,
+          overall_decision: 'refused'
+        },
+        Reviewing::Completed, Time.zone.local(2022, 9, 4),
+        {
+          entity_id:,
+          entity_type:,
+          business_reference:
+        }
+      ]
+    end
+
+    it 'looks up the maat_id from the Decision record and calls the MAAT API' do
+      allow(maat_get_record).to receive(:by_maat_id!).and_raise(MAAT::RecordNotFound)
+      allow(Rails.error).to receive(:report)
+
+      sync_maat_record.call
+
+      expect(maat_get_record).to have_received(:by_maat_id!).with(7_654_321)
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
When syncing MAAT records during automated deletion, the SyncMAATRecord command was incorrectly passing decision_ids (internal UUIDs) directly to the MAAT API as if they were numeric MAAT reference numbers. The MAAT API expects a numeric maat_id (e.g. 9874622), not a UUID, so lookups via decision_ids would fail.

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRIMAPP-2222

## Notes for reviewer / how to test
