### PR TITLE
Temporarily suspend staging deletion cronjob

### DIFF
--- a/config/kubernetes/staging/automate-deletion-cron-job.tpl
+++ b/config/kubernetes/staging/automate-deletion-cron-job.tpl
@@ -9,6 +9,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      suspend: true
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Description of change
This change temporarily suspends the `automate-deletion-cron-job-staging` cronjob. This is to aid the testing of the 3-year data retention feature. As the retention period is currently set to 10 minutes for QA purposes, there are refused applications we don't want to be picked up by the deletion process until we run it manually.

## Link to relevant ticket
[Slack conversation](https://mojdt.slack.com/archives/C0AGX7834R2/p1782296728566039)