### PR TITLE
Temporarily suspend staging deletion cronjob (again)

### DIFF
--- a/config/kubernetes/staging/automate-deletion-cron-job.tpl
+++ b/config/kubernetes/staging/automate-deletion-cron-job.tpl
@@ -7,9 +7,9 @@ spec:
   schedule: "0 0 * * *" # daily at midnight
   timeZone: "Europe/London"
   concurrencyPolicy: Forbid
+  suspend: true
   jobTemplate:
     spec:
-      suspend: true
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Description of change
This change fixes a mistake in https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/545 where the `suspend` field was set in the wrong part of the configuration.
