### PR TITLE
Address deprecated event store features

### DIFF
--- a/app/api/datastore/v1/applications.rb
+++ b/app/api/datastore/v1/applications.rb
@@ -74,7 +74,8 @@ module Datastore
           resource :archive do
             route_setting :authorised_consumers, %w[crime-apply]
             put do
-              Operations::ArchiveApplication.new(application_id: params[:application_id]).call
+              app = Operations::ArchiveApplication.new(application_id: params[:application_id]).call
+              present app, with: Datastore::Entities::V1::CrimeApplication
             end
           end
         end

--- a/app/services/operations/archive_application.rb
+++ b/app/services/operations/archive_application.rb
@@ -19,6 +19,8 @@ module Operations
 
         Rails.configuration.event_store.publish(event)
       end
+
+      application
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/applying/lib/applying.rb
+++ b/applying/lib/applying.rb
@@ -1,5 +1,5 @@
 module Applying
-  class Event < RailsEventStore::Event
+  class Event < RubyEventStore::Event
     def self.from_application(crime_application)
       new(
         data: {

--- a/deciding/lib/deciding.rb
+++ b/deciding/lib/deciding.rb
@@ -1,5 +1,5 @@
 module Deciding
-  class Event < RailsEventStore::Event
+  class Event < RubyEventStore::Event
     def self.from_application(crime_application)
       new(
         data: {

--- a/deleting/lib/deleting.rb
+++ b/deleting/lib/deleting.rb
@@ -1,7 +1,7 @@
 module Deleting
   SOFT_DELETION_PERIOD = Rails.configuration.x.automated_deletion_test_mode == 'true' ? 10.minutes : 30.days
 
-  class Event < RailsEventStore::Event; end
+  class Event < RubyEventStore::Event; end
   class SoftDeleted < Event; end
   class HardDeleted < Event; end
   class ExemptFromDeletion < Event; end
@@ -35,8 +35,8 @@ module Deleting
 
   class Configuration
     class << self
-      def call(event_store) # rubocop:disable Metrics/MethodLength
-        event_store.subscribe(Deleting::Handlers::LinkToStream, to:
+      def call(event_store) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+        event_store.subscribe(Deleting::Handlers::LinkToStream.new, to:
           [
             Applying::DraftCreated,
             Applying::DraftDeleted,
@@ -48,14 +48,14 @@ module Deleting
             Deleting::ApplicationMigrated,
             Deleting::Archived
           ])
-        event_store.subscribe(Deleting::Handlers::UpdateReadModel, to: EVENTS)
-        event_store.subscribe(Deleting::Handlers::UpdateApplicationSoftDeleted, to: [Deleting::SoftDeleted])
-        event_store.subscribe(Deleting::Handlers::PublishSoftDeletedSns, to: [Deleting::SoftDeleted])
-        event_store.subscribe(Deleting::Handlers::PublishArchivedSns, to: [Deleting::Archived])
-        event_store.subscribe(Deleting::Handlers::ClearApplicationSoftDeleted, to: [Deleting::ExemptFromDeletion])
-        event_store.subscribe(Deleting::Handlers::DeleteUnsubmittedDeletableEntity, to: [Applying::DraftDeleted])
-        event_store.subscribe(Deleting::Handlers::HardDeleteDocuments, to: [Deleting::HardDeleted])
-        event_store.subscribe(Deleting::Handlers::HardDeleteSubmittedApplications, to: [Deleting::HardDeleted])
+        event_store.subscribe(Deleting::Handlers::UpdateReadModel.new, to: EVENTS)
+        event_store.subscribe(Deleting::Handlers::UpdateApplicationSoftDeleted.new, to: [Deleting::SoftDeleted])
+        event_store.subscribe(Deleting::Handlers::PublishSoftDeletedSns.new, to: [Deleting::SoftDeleted])
+        event_store.subscribe(Deleting::Handlers::PublishArchivedSns.new, to: [Deleting::Archived])
+        event_store.subscribe(Deleting::Handlers::ClearApplicationSoftDeleted.new, to: [Deleting::ExemptFromDeletion])
+        event_store.subscribe(Deleting::Handlers::DeleteUnsubmittedDeletableEntity.new, to: [Applying::DraftDeleted])
+        event_store.subscribe(Deleting::Handlers::HardDeleteDocuments.new, to: [Deleting::HardDeleted])
+        event_store.subscribe(Deleting::Handlers::HardDeleteSubmittedApplications.new, to: [Deleting::HardDeleted])
       end
     end
   end

--- a/reviewing/lib/reviewing.rb
+++ b/reviewing/lib/reviewing.rb
@@ -1,5 +1,5 @@
 module Reviewing
-  class Event < RailsEventStore::Event
+  class Event < RubyEventStore::Event
     def self.from_application(crime_application)
       new(
         data: {

--- a/spec/deleting/automate_deletion_completed_without_decision_spec.rb
+++ b/spec/deleting/automate_deletion_completed_without_decision_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe Deleting::AutomateDeletion do
   let(:event_stream) { "Deleting$#{business_reference}" }
   let(:current_date) { Time.zone.local(2025, 9, 6) }
   let(:soft_deleted_event) { instance_double(Events::SoftDeleted, publish: true) }
-  let(:hard_delete_submitted_applications) { instance_double(Deleting::Handlers::HardDeleteSubmittedApplications) }
-  let(:hard_delete_documents) { instance_double(Deleting::Handlers::HardDeleteDocuments) }
   let(:maat_get_record) { instance_double(MAAT::GetRecord) }
 
   before do
@@ -99,14 +97,12 @@ RSpec.describe Deleting::AutomateDeletion do
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
-        allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new) {
-          hard_delete_submitted_applications
+        allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call) { |_, event|
+          @hard_delete_documents_event = event
         }
-        allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new) {
-          hard_delete_documents
+        allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call) { |_, event|
+          @hard_delete_submitted_applications_event = event
         }
-        allow(hard_delete_documents).to receive(:call)
-        allow(hard_delete_submitted_applications).to receive(:call)
         allow(MAAT::GetRecord).to receive(:new).and_return(maat_get_record)
         allow(maat_get_record).to receive(:by_maat_id!) do
           raise MAAT::RecordNotFound if maat_record.nil?
@@ -257,15 +253,12 @@ RSpec.describe Deleting::AutomateDeletion do
           end
 
           it 'deletion of documents occurs' do
-            expect(hard_delete_documents).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
           end
 
           it 'deletion of submitted applications occurs' do
-            expect(hard_delete_submitted_applications).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+              .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
           end
 
           it 'removes deletable_entities record' do
@@ -380,14 +373,8 @@ RSpec.describe Deleting::AutomateDeletion do
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
-        allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new) {
-          hard_delete_submitted_applications
-        }
-        allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new) {
-          hard_delete_documents
-        }
-        allow(hard_delete_documents).to receive(:call)
-        allow(hard_delete_submitted_applications).to receive(:call)
+        allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call)
+        allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call)
         allow(MAAT::GetRecord).to receive(:new).and_return(maat_get_record)
         allow(maat_get_record).to receive(:by_usn!).with(business_reference.to_s).and_return(maat_record)
         allow(maat_get_record).to receive(:by_maat_id!)

--- a/spec/deleting/automate_deletion_refused_application_spec.rb
+++ b/spec/deleting/automate_deletion_refused_application_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe Deleting::AutomateDeletion do
   let(:event_stream) { "Deleting$#{business_reference}" }
   let(:current_date) { Time.zone.local(2025, 9, 6) }
   let(:soft_deleted_event) { instance_double(Events::SoftDeleted, publish: true) }
-  let(:hard_delete_submitted_applications) { instance_double(Deleting::Handlers::HardDeleteSubmittedApplications) }
-  let(:hard_delete_documents) { instance_double(Deleting::Handlers::HardDeleteDocuments) }
   let(:maat_get_record) { instance_double(MAAT::GetRecord) }
 
   before do
@@ -149,15 +147,12 @@ RSpec.describe Deleting::AutomateDeletion do
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
-        allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new) {
-          hard_delete_submitted_applications
+        allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call) { |_, event|
+          @hard_delete_documents_event = event
         }
-
-        allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new) {
-          hard_delete_documents
+        allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call) { |_, event|
+          @hard_delete_submitted_applications_event = event
         }
-        allow(hard_delete_documents).to receive(:call)
-        allow(hard_delete_submitted_applications).to receive(:call)
         allow(MAAT::GetRecord).to receive(:new).and_return(maat_get_record)
         allow(maat_get_record).to receive(:by_maat_id!) do
           raise MAAT::RecordNotFound if maat_record.nil?
@@ -249,15 +244,12 @@ RSpec.describe Deleting::AutomateDeletion do
           end
 
           it 'deletion of documents occurs' do
-            expect(hard_delete_documents).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
           end
 
           it 'deletion of submitted applications occurs' do
-            expect(hard_delete_submitted_applications).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+              .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
           end
 
           it 'removes deletable_entities record' do
@@ -409,15 +401,12 @@ RSpec.describe Deleting::AutomateDeletion do
         allow(Events::SoftDeleted).to receive(:new)
           .with(reference: crime_application.reference, soft_deleted_at: current_date)
           .and_return(soft_deleted_event)
-        allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new) {
-          hard_delete_submitted_applications
+        allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call) { |_, event|
+          @hard_delete_documents_event = event
         }
-
-        allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new) {
-          hard_delete_documents
+        allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call) { |_, event|
+          @hard_delete_submitted_applications_event = event
         }
-        allow(hard_delete_documents).to receive(:call)
-        allow(hard_delete_submitted_applications).to receive(:call)
         allow(MAAT::GetRecord).to receive(:new).and_return(maat_get_record)
         allow(maat_get_record).to receive(:by_maat_id!) do
           raise MAAT::RecordNotFound if maat_record.nil?
@@ -509,15 +498,12 @@ RSpec.describe Deleting::AutomateDeletion do
           end
 
           it 'deletion of documents occurs' do
-            expect(hard_delete_documents).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
           end
 
           it 'deletion of submitted applications occurs' do
-            expect(hard_delete_submitted_applications).to have_received(:call).with(
-              events_in_stream.of_type([Deleting::HardDeleted]).first
-            )
+            expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+              .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
           end
 
           it 'removes deletable_entities record' do

--- a/spec/deleting/automate_deletion_returned_application_spec.rb
+++ b/spec/deleting/automate_deletion_returned_application_spec.rb
@@ -16,27 +16,21 @@ RSpec.describe Deleting::AutomateDeletion do
   let(:maat_id) { '987654321' }
   let(:event_stream) { "Deleting$#{business_reference}" }
   let(:current_date) { Time.zone.local(2025, 9, 6) }
-  let(:hard_delete_submitted_applications) { instance_double(Deleting::Handlers::HardDeleteSubmittedApplications) }
-  let(:hard_delete_documents) { instance_double(Deleting::Handlers::HardDeleteDocuments) }
   let(:soft_deleted_event) { instance_double(Events::SoftDeleted, publish: true) }
 
   before do
-    allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new) {
-      hard_delete_submitted_applications
+    allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call) { |_, event|
+      @hard_delete_documents_event = event
     }
-
-    allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new) {
-      hard_delete_documents
+    allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call) { |_, event|
+      @hard_delete_submitted_applications_event = event
     }
-
-    allow(hard_delete_documents).to receive(:call)
-    allow(hard_delete_submitted_applications).to receive(:call)
 
     travel_to current_date
   end
 
   describe 'Returned application' do
-    context 'when sent back 2 years ago and not injected into MAAT' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'when sent back 2 years ago and not injected into MAAT' do
       let(:events) do
         [
           Applying::DraftCreated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },
@@ -86,7 +80,7 @@ RSpec.describe Deleting::AutomateDeletion do
         expect(soft_deleted_event).to have_received(:publish)
       end
 
-      context 'when soft deletion period has passed' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'when soft deletion period has passed' do
         before do
           travel_to current_date + Deleting::SOFT_DELETION_PERIOD
           automate_deletion.call
@@ -109,15 +103,12 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'deletion of documents occurs' do
-          expect(hard_delete_documents).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
         end
 
         it 'deletion of submitted applications occurs' do
-          expect(hard_delete_submitted_applications).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+            .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
         end
 
         it 'removes deletable_entities record' do
@@ -228,15 +219,12 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'deletion of documents occurs' do
-          expect(hard_delete_documents).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
         end
 
         it 'deletion of submitted applications occurs' do
-          expect(hard_delete_submitted_applications).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+            .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
         end
 
         it 'removes deletable_entities record' do
@@ -332,15 +320,12 @@ RSpec.describe Deleting::AutomateDeletion do
         end
 
         it 'deletion of documents occurs' do
-          expect(hard_delete_documents).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_documents_event).to eq(events_in_stream.of_type([Deleting::HardDeleted]).first) # rubocop:disable RSpec/InstanceVariable
         end
 
         it 'deletion of submitted applications occurs' do
-          expect(hard_delete_submitted_applications).to have_received(:call).with(
-            events_in_stream.of_type([Deleting::HardDeleted]).first
-          )
+          expect(@hard_delete_submitted_applications_event) # rubocop:disable RSpec/InstanceVariable
+            .to eq(events_in_stream.of_type([Deleting::HardDeleted]).first)
         end
 
         it 'removes deletable_entities record' do
@@ -349,7 +334,7 @@ RSpec.describe Deleting::AutomateDeletion do
       end
     end
 
-    context 'when sent back 2 years ago and has active drafts' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'when sent back 2 years ago and has active drafts' do
       let(:events) do
         [
           Applying::DraftCreated, Time.zone.local(2023, 8, 31), { entity_id:, entity_type:, business_reference: },

--- a/spec/deleting/commands/exempt_spec.rb
+++ b/spec/deleting/commands/exempt_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe Deleting::Commands::Exempt do
         }), stream_name: event_stream)
       end
 
-      allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new)
-      allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new)
+      allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call)
+      allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call)
 
       event_store.publish(Deleting::HardDeleted.new(data:
         {

--- a/spec/lib/tasks/backfill_reference_history_events_spec.rb
+++ b/spec/lib/tasks/backfill_reference_history_events_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'backfill_reference_history_events' do # rubocop:disable RSpec/De
     before do
       Rake::Task['publish_soft_deleted_sns_events'].reenable
       stub_const('ENV', ENV.to_h.merge('DRY_RUN' => nil, 'LIMIT' => nil, 'START_AFTER_ID' => nil))
-      allow(Deleting::Handlers::PublishSoftDeletedSns).to receive(:new).and_return(double(call: nil)) # rubocop:disable RSpec/VerifiedDoubles
+      allow_any_instance_of(Deleting::Handlers::PublishSoftDeletedSns).to receive(:call)
       soft_deleted_application
       event_store.publish(soft_deleted_event)
     end

--- a/spec/lib/tasks/cleanup_recreated_deletable_entities_spec.rb
+++ b/spec/lib/tasks/cleanup_recreated_deletable_entities_spec.rb
@@ -30,19 +30,14 @@ RSpec.describe 'cleanup_recreated_deletable_entities' do # rubocop:disable RSpec
     ]
   end
 
-  let(:hard_delete_documents) { instance_double(Deleting::Handlers::HardDeleteDocuments) }
-  let(:hard_delete_submitted_applications) { instance_double(Deleting::Handlers::HardDeleteSubmittedApplications) }
   let(:soft_deleted_event) { instance_double(Events::SoftDeleted, publish: true) }
 
   before do
     Rake::Task['cleanup_recreated_deletable_entities'].reenable
     stub_const('ENV', ENV.to_h.merge('DRY_RUN' => nil))
 
-    allow(Deleting::Handlers::HardDeleteDocuments).to receive(:new).and_return(hard_delete_documents)
-    allow(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:new)
-      .and_return(hard_delete_submitted_applications)
-    allow(hard_delete_documents).to receive(:call)
-    allow(hard_delete_submitted_applications).to receive(:call)
+    allow_any_instance_of(Deleting::Handlers::HardDeleteDocuments).to receive(:call)
+    allow_any_instance_of(Deleting::Handlers::HardDeleteSubmittedApplications).to receive(:call)
     allow(Events::SoftDeleted).to receive(:new).and_return(soft_deleted_event)
 
     travel_to current_date


### PR DESCRIPTION
## Description of change
This address deprecations introduced by the latest upgrade to `rails_event_store` (via an upgrade to `aggregate_root` https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/551).

> Deprecate: Class as subscriber — use an instance or lambda [https://github.com/RailsEventStore/rails_event_store/pull/1929]
> Deprecate: RailsEventStore::* constant aliases — use RubyEventStore::* directly [https://github.com/RailsEventStore/rails_event_store/pull/1929]

- `RailsEventStore::Event` has been replaced by `RubyEventStore::Event`
- `event_store.subscribe` now takes a handler **instance** rather than a handler class
    - one notable side-effect from this change is that the `archive` endpoint started throwing a stack overflow exception -- this was due to the fact that `Operations::ArchiveApplication::call` was returning an instance of the event store, which Grape was serializing as JSON. This wasn't an issue with handler classes, but using handler instances introduces a circular dependency and causes a stack overflow. This is a bug - the method should not have been returning an event store instance anyway. It now returns the updated application, in line with the other endpoints.

Relevant specs have been updated.