### PR TITLE
[CRIMAPP-2222] Extend refused retention period in test mode

### DIFF
--- a/deleting/lib/deleting/deletable.rb
+++ b/deleting/lib/deleting/deletable.rb
@@ -276,14 +276,14 @@ module Deleting
 
     # TODO: remove after 3-year retention QA
     def refused_retention_period
-      return 10.minutes if Rails.configuration.x.automated_deletion_test_mode == 'true'
+      return 1.day if Rails.configuration.x.automated_deletion_test_mode == 'true'
 
       3.years
     end
 
     # TODO: remove after 3-year retention QA
     def no_decision_retention_period
-      return 10.minutes if Rails.configuration.x.automated_deletion_test_mode == 'true'
+      return 1.day if Rails.configuration.x.automated_deletion_test_mode == 'true'
 
       3.years
     end


### PR DESCRIPTION
## Description of change
Extend the retention period for refused applications from 10 minutes to 1 day in test mode. This will allow us to QA one remaining scenario that requires a longer retention period - scenario C2 in the test matrix.

## Link to relevant ticket
[CRIMAPP-2222](https://dsdmoj.atlassian.net/browse/CRIMAPP-2222)


[CRIMAPP-2222]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ