### PR TITLE
Fix Sentry event data filtering

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -21,7 +21,23 @@ Rails.application.config.to_prepare do
     )
 
     config.before_send = lambda do |event, _hint|
-      params_filter.filter(event.to_hash)
+      if event.request
+        event.request.data = params_filter.filter(event.request.data) if event.request.data
+        event.request.cookies = params_filter.filter(event.request.cookies) if event.request.cookies
+        event.request.headers&.delete('Authorization')
+        event.request.headers&.delete('HTTP_AUTHORIZATION')
+
+        if event.request.query_string.present?
+          parsed = Rack::Utils.parse_nested_query(event.request.query_string)
+          event.request.query_string = params_filter.filter(parsed).to_query
+        end
+      end
+
+      if event.user
+        event.user = params_filter.filter(event.user)
+      end
+
+      event
     end
   end
 end

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/DescribeClass
+  subject(:result) { Sentry.configuration.before_send.call(event, {}) }
+
+  let(:event) do
+    Sentry::ErrorEvent.new(configuration: Sentry.configuration).tap do |e|
+      e.user = { 'last_name' => 'Smith', 'first_name' => 'John', 'id' => 'safe-id' }
+    end
+  end
+
+  it 'returns a Sentry::ErrorEvent' do
+    expect(result).to be_a(Sentry::ErrorEvent)
+  end
+
+  describe 'user field filtering' do
+    it 'filters sensitive user fields' do
+      expect(result.user['last_name']).to eq('[FILTERED]')
+      expect(result.user['first_name']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive user fields' do
+      expect(result.user['id']).to eq('safe-id')
+    end
+  end
+
+  describe 'request data filtering' do
+    let(:request_interface) do
+      Sentry::RequestInterface.new(
+        env: Rack::MockRequest.env_for('/test'),
+        send_default_pii: false,
+        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
+      ).tap do |r|
+        r.data    = { 'search_text' => 'sensitive details', 'action' => 'submit' }
+        r.cookies = { 'token' => 'abc123', '_ga' => 'safe-ga-value' }
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'filters sensitive fields in request data' do
+      expect(result.request.data['search_text']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive fields in request data' do
+      expect(result.request.data['action']).to eq('submit')
+    end
+
+    it 'filters sensitive fields in cookies' do
+      expect(result.request.cookies['token']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive cookie values' do
+      expect(result.request.cookies['_ga']).to eq('safe-ga-value')
+    end
+  end
+
+  describe 'request header filtering' do
+    let(:request_interface) do
+      Sentry::RequestInterface.new(
+        env: Rack::MockRequest.env_for('/test'),
+        send_default_pii: false,
+        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
+      ).tap do |r|
+        r.headers = { 'Authorization' => 'Bearer token123', 'Content-Type' => 'application/json' }
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'removes the Authorization header' do
+      expect(result.request.headers).not_to have_key('Authorization')
+    end
+
+    it 'preserves non-sensitive headers' do
+      expect(result.request.headers['Content-Type']).to eq('application/json')
+    end
+  end
+
+  describe 'query string filtering' do
+    let(:request_interface) do
+      Sentry::RequestInterface.new(
+        env: Rack::MockRequest.env_for('/test'),
+        send_default_pii: false,
+        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
+      ).tap do |r|
+        r.query_string = 'search_text=sensitive+name&page=2'
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'filters sensitive query string parameters' do
+      parsed = Rack::Utils.parse_nested_query(result.request.query_string)
+      expect(parsed['search_text']).to eq('[FILTERED]')
+    end
+
+    it 'preserves non-sensitive query string parameters' do
+      parsed = Rack::Utils.parse_nested_query(result.request.query_string)
+      expect(parsed['page']).to eq('2')
+    end
+  end
+end

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/Describe
     end
   end
 
+  def build_request_interface
+    Sentry::RequestInterface.new(
+      env: Rack::MockRequest.env_for('/test'),
+      send_default_pii: false,
+      rack_env_whitelist: Sentry.configuration.rack_env_whitelist
+    )
+  end
+
   it 'returns a Sentry::ErrorEvent' do
     expect(result).to be_a(Sentry::ErrorEvent)
   end
@@ -26,11 +34,7 @@ RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/Describe
 
   describe 'request data filtering' do
     let(:request_interface) do
-      Sentry::RequestInterface.new(
-        env: Rack::MockRequest.env_for('/test'),
-        send_default_pii: false,
-        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
-      ).tap do |r|
+      build_request_interface.tap do |r|
         r.data    = { 'search_text' => 'sensitive details', 'action' => 'submit' }
         r.cookies = { 'token' => 'abc123', '_ga' => 'safe-ga-value' }
       end
@@ -57,11 +61,7 @@ RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/Describe
 
   describe 'request header filtering' do
     let(:request_interface) do
-      Sentry::RequestInterface.new(
-        env: Rack::MockRequest.env_for('/test'),
-        send_default_pii: false,
-        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
-      ).tap do |r|
+      build_request_interface.tap do |r|
         r.headers = { 'Authorization' => 'Bearer token123', 'Content-Type' => 'application/json' }
       end
     end
@@ -79,11 +79,7 @@ RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/Describe
 
   describe 'query string filtering' do
     let(:request_interface) do
-      Sentry::RequestInterface.new(
-        env: Rack::MockRequest.env_for('/test'),
-        send_default_pii: false,
-        rack_env_whitelist: Sentry.configuration.rack_env_whitelist
-      ).tap do |r|
+      build_request_interface.tap do |r|
         r.query_string = 'search_text=sensitive+name&page=2'
       end
     end
@@ -98,6 +94,90 @@ RSpec.describe 'Sentry before_send callback' do # rubocop:disable RSpec/Describe
     it 'preserves non-sensitive query string parameters' do
       parsed = Rack::Utils.parse_nested_query(result.request.query_string)
       expect(parsed['page']).to eq('2')
+    end
+
+    context 'when query_string is blank' do
+      before { request_interface.query_string = '' }
+
+      it 'does not modify query_string' do
+        expect(result.request.query_string).to eq('')
+      end
+    end
+  end
+
+  context 'when event.request is nil' do
+    before { allow(event).to receive(:request).and_return(nil) }
+
+    it 'returns the event without error' do
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+  end
+
+  context 'when event.user is blank' do
+    let(:event) { Sentry::ErrorEvent.new(configuration: Sentry.configuration) }
+
+    it 'returns the event without error' do
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'leaves user as blank' do
+      expect(result.user).to eq({})
+    end
+  end
+
+  context 'when request.data is nil' do
+    let(:request_interface) do
+      build_request_interface.tap do |r|
+        r.data    = nil
+        r.cookies = { 'token' => 'abc123' }
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'returns the event without error' do
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'leaves data as nil' do
+      expect(result.request.data).to be_nil
+    end
+  end
+
+  context 'when request.cookies is nil' do
+    let(:request_interface) do
+      build_request_interface.tap do |r|
+        r.data    = { 'action' => 'submit' }
+        r.cookies = nil
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'returns the event without error' do
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'leaves cookies as nil' do
+      expect(result.request.cookies).to be_nil
+    end
+  end
+
+  context 'when request.headers is nil' do
+    let(:request_interface) do
+      build_request_interface.tap do |r|
+        r.headers = nil
+      end
+    end
+
+    before { allow(event).to receive(:request).and_return(request_interface) }
+
+    it 'returns the event without error' do
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'leaves headers as nil' do
+      expect(result.request.headers).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Description of change
This attempts to fix an issue where Sentry is no longer receiving alerts from the application due to an exception caused by code in the `before_send` callback in the Sentry initializer (`sentry.rb`). This code is meant to filter out sensitive data from the error event as defined in `filter_parameter_logging.rb`.

The breaking changes were introduced with `sentry-ruby v6.0.0`:
> Migrate from to_hash to to_h (https://github.com/getsentry/sentry-ruby/pull/2351)
> Returning a hash from before_send and before_send_transaction is no longer supported and will drop the event.

[Full release log](https://github.com/getsentry/sentry-ruby/releases/tag/6.0.0).

Examples of silent exceptions in our logs: [here](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!t,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1M,to:now))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-apply-for-criminal-legal-aid-production),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-apply-for-criminal-legal-aid-production)))),query:(language:kuery,query:'%22sentry:%20exception%20happened%20in%20background%20worker:%20undefined%20method%20!'to_hash!'%20for%20an%20instance%20of%20Sentry::ErrorEvent%22'))).

Relevant Sentry docs:
https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/#using-before-send
https://develop.sentry.dev/sdk/foundations/transport/event-payloads/request/

## Notes for reviewer / how to test
In a Rails console on staging, run the following to raise an exception that should be picked up by Sentry and create an alert in our alerts channel:
```ruby
begin
  raise 'Sentry connectivity test'
rescue => e
  Rails.error.report(e, handled: false)
end
```