### PR TITLE
Pin localstack image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   # Used to emulate AWS for local development
-  # Pinned to 4.4.0 as later versions require a paid license (LOCALSTACK_AUTH_TOKEN)
+  # Pinned to 4.4.0 as later versions require a paid license
   localstack:
     image: localstack/localstack:4.4.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   # Used to emulate AWS for local development
+  # Pinned to 4.4.0 as later versions require a paid license (LOCALSTACK_AUTH_TOKEN)
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.4.0
     ports:
       - "4566:4566" # localstack gateway
       - "4510-4559:4510-4559" # external services port range


### PR DESCRIPTION
## Description of change
Pinned localstack image version to 4.4.0 as later versions require a paid license. This was preventing localstack from being built with `docker compose up localstack --build` and blocking local evidence upload testing

## Link to relevant ticket

## Notes for reviewer / how to test
