### PR TITLE
Bump moj-simple-jwt-auth from 0.1.0 to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,9 @@ gem 'sentry-ruby'
 gem 'stackprof'
 
 # Datastore API authentication
-gem 'moj-simple-jwt-auth', '0.1.0'
+gem 'moj-simple-jwt-auth',
+    github: 'ministryofjustice/moj-simple-jwt-auth',
+    tag: 'v0.2.0'
 
 # AWS services
 gem 'aws-sdk-s3'

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,7 @@ gem 'sentry-ruby'
 gem 'stackprof'
 
 # Datastore API authentication
-gem 'moj-simple-jwt-auth',
-    github: 'ministryofjustice/moj-simple-jwt-auth',
-    tag: 'v0.2.0'
+gem 'moj-simple-jwt-auth', '0.2.0'
 
 # AWS services
 gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,15 @@ GIT
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
+GIT
+  remote: https://github.com/ministryofjustice/moj-simple-jwt-auth.git
+  revision: bcb92d0d65b4cf2765de1619f403f5664cc9c81b
+  tag: v0.2.0
+  specs:
+    moj-simple-jwt-auth (0.2.0)
+      json
+      jwt
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -239,9 +248,6 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    moj-simple-jwt-auth (0.1.0)
-      json
-      jwt
     multi_json (1.15.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -469,7 +475,7 @@ DEPENDENCIES
   grape_logging
   kaminari-activerecord
   laa-criminal-legal-aid-schemas!
-  moj-simple-jwt-auth (= 0.1.0)
+  moj-simple-jwt-auth!
   oauth2
   ostruct (~> 0.6.3)
   pg (~> 1.6.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,6 @@ GIT
       dry-struct (~> 1.6.0)
       json-schema (~> 4.0.0)
 
-GIT
-  remote: https://github.com/ministryofjustice/moj-simple-jwt-auth.git
-  revision: bcb92d0d65b4cf2765de1619f403f5664cc9c81b
-  tag: v0.2.0
-  specs:
-    moj-simple-jwt-auth (0.2.0)
-      json
-      jwt
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -248,6 +239,9 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    moj-simple-jwt-auth (0.2.0)
+      json
+      jwt
     multi_json (1.15.0)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
@@ -475,7 +469,7 @@ DEPENDENCIES
   grape_logging
   kaminari-activerecord
   laa-criminal-legal-aid-schemas!
-  moj-simple-jwt-auth!
+  moj-simple-jwt-auth (= 0.2.0)
   oauth2
   ostruct (~> 0.6.3)
   pg (~> 1.6.3)


### PR DESCRIPTION
## Description of change
This change upgrades `moj-simple-jwt-auth` to `v0.2.0`, which should fix the breaking changes preventing us from upgrading `grape` to `v2.4` and higher.

## Link to relevant ticket
[CRIMAPP-2273](https://dsdmoj.atlassian.net/browse/CRIMAPP-2273)


[CRIMAPP-2273]: https://dsdmoj.atlassian.net/browse/CRIMAPP-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ