### PR TITLE
Bump devsecops-hooks to 2.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.5.0
+    rev: 53d252e406bae2bbbd0c0f3205b72870a02c9b3f  # v2.0.2
     hooks:
       - id: baseline
         env:


### PR DESCRIPTION
## Description of change
Bump `devsecops-hooks` to 2.0.2.